### PR TITLE
Using pep440 version string.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,27 @@
+import os
 from setuptools import setup
+
+rootpath = os.path.abspath(os.path.dirname(__file__))
+
 
 def readme():
     with open('README.md') as f:
         return f.read()
 
+
+def extract_version():
+    version = None
+    fname = os.path.join(rootpath, 'utide', '__init__.py')
+    with open(fname) as f:
+        for line in f:
+            if (line.startswith('__version__')):
+                _, version = line.split('=')
+                version = version.strip()[1:-1]  # Remove quotation characters
+                break
+    return version
+
 setup(name='UTide',
-      version='v1p0',
+      version=extract_version(),
       description='Python distribution of the MatLab package UTide.',
       long_description=readme(),
       url='https://github.com/wesleybowman/UTide',

--- a/utide/__init__.py
+++ b/utide/__init__.py
@@ -8,4 +8,5 @@ from ut_solv import ut_solv
 from ut_reconstr import ut_reconstr
 from simple_utide_test import simple_utide_test
 
-__version__ = 'v1p0'
+
+__version__ = '0.1b0.dev0'


### PR DESCRIPTION
- using [pep440](https://www.python.org/dev/peps/pep-0440/) for the version
- finding the version from `__init__.py` to avoid confusion/fragmentation