### PR TITLE
Reduce memory and time requirement for Lomb-Scargle spectral calculation.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [pytest]
 python_files = *.py
-addopts = --verbose --ignore setup.py --ignore utide/robustfit.py --doctest-modules --cov-report term-missing --cov .
-norecursedirs = utide/tests build
+addopts = --verbose --ignore setup.py --ignore utide/robustfit.py
+norecursedirs = build data dist doc .git *.egg

--- a/utide/robustfit.py
+++ b/utide/robustfit.py
@@ -103,15 +103,15 @@ def welsch(r):
     return w
 
 
-def test(r):
-    print(andrews(r))
-    print(bisquare(r))
-    print(cauchy(r))
-    print(fair(r))
-    print(huber(r))
-    print(logistic(r))
-    print(talwar(r))
-    print(welsch(r))
+#def test(r):
+#    print(andrews(r))
+#    print(bisquare(r))
+#    print(cauchy(r))
+#    print(fair(r))
+#    print(huber(r))
+#    print(logistic(r))
+#    print(talwar(r))
+#    print(welsch(r))
 
 #        case 'andrews'
 #            wfun = @andrews;


### PR DESCRIPTION

The calculation is done only on frequencies within the bands that
will be averaged.  The number of frequencies in a band is limited
by a parameter that is initially set to 500; this can be changed
and/or made an option later, if desired.  I suspect 100 would be
adequate.

I also modified the py.test options in setup.cfg; there were a
couple that were not recognized, and others that it seemed reasonable
to change.