### PR TITLE
modify and document user interface; use Bunch

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -28,6 +28,7 @@ Contents:
    :maxdepth: 2
 
    strategy
+   usage
    internals/index.rst
 
 Indices and tables

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -1,0 +1,24 @@
+################
+Usage
+################
+
+.. toctree::
+   :maxdepth: 1
+
+solve
+-----
+.. autofunction:: utide.solve
+
+reconstruct
+-----------
+.. autofunction:: utide.reconstruct
+
+Bunch
+-----
+The data structure used internally and to hold the output from
+`solve` is a hybrid; it is a dictionary subclass that provides
+attribute access to its data.  For example, ``coef['aux']`` and
+``coef.aux`` can be used interchangeably.
+
+.. autofunction:: utide.utilities.Bunch
+

--- a/utide/_reconstruct.py
+++ b/utide/_reconstruct.py
@@ -2,13 +2,37 @@ from __future__ import absolute_import, division
 
 import numpy as np
 from .harmonics import ut_E
+from .utilities import Bunch
 
+def reconstruct(t, coef, **opts):
+    """
+    Reconstruct a tidal signal.
 
-def reconstruct(tin, coef, **opts):
+    Parameters
+    ----------
+    t : array_like
+        Time in days since `epoch`.
+    coef : `Bunch`
+        Data structure returned by `utide.solve`
+    epoch : {string, int, `datetime.datetime`}, optional
+        Not implemented yet. It will default to the epoch
+        used for `coef`.
 
-    u, v = _reconstr1(tin, coef, **opts)
+    Returns
+    -------
+    tide : `Bunch`
+        Scalar time series is returned as `tide.h`; a vector
+        series as `tide.u`, `tide.v`.
 
-    return u, v
+    """
+
+    out = Bunch()
+    u, v = _reconstr1(t, coef, **opts)
+    if coef['aux']['opt']['twodim']:
+        out.u, out.v = u, v
+    else:
+        out.h = u
+    return out
 
 
 def _reconstr1(tin, coef, **opts):

--- a/utide/_solve.py
+++ b/utide/_solve.py
@@ -316,7 +316,7 @@ def _slvinit(tin, uin, vin, lat, **opts):
     if vin is not None and vin.shape != uin.shape:
         raise ValueError("v must have the same shape as u")
 
-    opt = dict(twodim=(vin is not None))
+    opt = Bunch(twodim=(vin is not None))
 
     # Step 1: remove invalid times from tin, uin, vin
     tin = np.ma.masked_invalid(tin)

--- a/utide/_solve.py
+++ b/utide/_solve.py
@@ -272,7 +272,6 @@ def _solv1(tin, uin, vin, lat, **opts):
     else:    # any other string: order by decreasing energy
         if not opt['nodiagn']:
             ind = indPE
-
         else:
             if opt['twodim']:
                 PE = np.sum(coef['Lsmaj']**2 + coef['Lsmin']**2)
@@ -283,14 +282,14 @@ def _solv1(tin, uin, vin, lat, **opts):
             ind = PE.argsort()[::-1]
 
     reorderlist = ['g', 'name']
-    if opt['twodim']:
-        reorderlist += ['Lsmaj', 'Lsmin', 'theta']
-        if opt['conf_int']:
-            reorderlist += ['Lsmaj_ci', 'Lsmin_ci', 'theta_ci', 'g_ci']
+    if opt.twodim:
+        reorderlist.extend(['Lsmaj', 'Lsmin', 'theta'])
+        if opt.conf_int:
+            reorderlist.extend(['Lsmaj_ci', 'Lsmin_ci', 'theta_ci', 'g_ci'])
     else:
-        reorderlist += ['A']
-        if opt['conf_int']:
-            reorderlist += ['A_ci']
+        reorderlist.append('A')
+        if opt.conf_int:
+            reorderlist.extend(['A_ci', 'g_ci'])
 
     for key in reorderlist:
         coef[key] = coef[key][ind]

--- a/utide/_solve.py
+++ b/utide/_solve.py
@@ -11,39 +11,123 @@ from .diagnostics import ut_diagn
 from .ellipse_params import ut_cs2cep
 from .constituent_selection import ut_cnstitsel
 from .confidence import _confidence
+from .utilities import Bunch
 from . import constit_index_dict
 
-def solve(tin, uin, vin=None, lat=None, **opts):
-    '''
-    Need to put in docstring and figure a good way to put in all the optional
-    parameters
+default_opts = dict(constit='auto',
+                    conf_int='linear',
+                    method='ols',
+                    trend=True,
+                    phase='Greenwich',
+                    nodal=True,
+                    infer='none',
+                    MC_n=200,
+                    Rayleigh_min=1,
+                    robust_kw=dict(),
+                    white=False,
+                    )
 
-    Keyword Arguments:
-    conf_int=True
-    cnstit='auto'
-    notrend=0
-    prefilt=[]
-    nodsatlint=0
-    nodsatnone=0
-    gwchlint=0
-    gwchnone=0
-    infer=[]
-    inferaprx=0
-    rmin=1
-    method='cauchy'
-    tunrdn=1
-    linci=0
-    white=0
-    nrlzn=200
-    lsfrqosmp=1
-    nodiagn=0
-    diagnplots=0
-    diagnminsnr=2
-    ordercnstit=None
-    runtimedisp='yyy'
-    '''
+def _process_opts(opts):
+    newopts = Bunch(default_opts)
+    newopts.update_values(strict=True, **opts)
+    # TODO: add more validation
+    return newopts
 
-    coef = _solv1(tin, uin, vin, lat, **opts)
+def _translate_opts(opts):
+    # Temporary shim between new-style options and Matlab heritage.
+    oldopts = Bunch()
+    oldopts.cnstit = opts.constit
+    oldopts.conf_int = (opts.conf_int != 'none')
+    if oldopts.conf_int:
+        oldopts.linci = True
+    oldopts.notrend = not opts.trend
+    if opts.nodal:
+        oldopts['nodsatlint'] = True
+    else:
+        oldopts['nodsatnone'] = True
+    if opts.phase == 'Greenwich':
+        oldopts['gwchlint'] = True
+    else:
+        oldopts['gwchnone'] = True
+    oldopts.rmin = opts.Rayleigh_min
+    oldopts.white = opts.white
+    return oldopts
+
+def solve(t, u, v=None, lat=None, **opts):
+    """
+    Calculate amplitude, phase, confidence intervals of tidal constituents.
+
+    Parameters
+    ----------
+    t : array_like
+        Time in days since `epoch`.
+    u : array_like
+        Sea-surface height, velocity component, etc.
+    v : {None, array_like}, optional
+        If `u` is a velocity component, `v` is the orthogonal component.
+    lat : float
+        Latitude in degrees; required.
+    epoch : {string, int, `datetime.datetime`}
+        Not implemented yet.
+    constit : {'auto', array_like}, optional
+        List of strings with standard letter abbreviations of
+        tidal constituents; or 'auto' to let the list be determined
+        based on the time span.
+    conf_int : {'linear', 'MC', 'none'}, optional
+        If not 'none' (string), calculate linearized confidence
+        intervals, or use a Monte-Carlo simulation (not yet
+        implemented).
+    method : {'ols', 'robust'}, optional
+        Solve with ordinary least squares, or with a robust algorithm.
+        If the latter, see `robust_kw` below.  The robust method is
+        not yet implemented.
+    trend : bool, optional
+        True (default) to include a linear trend in the model.
+    phase : {'Greenwich', 'raw'}, optional
+        Give Greenwich-referenced phase lags, or raw lags.
+    nodal : bool, optional
+        True (default) to include nodal/satellite corrections.
+
+
+    Returns
+    -------
+    coef : Bunch
+        Data container with all configuration and solution information:
+
+    Other Parameters
+    ----------------
+    infer : {'none', dict or Bunch}, optional
+        Not yet implemented.
+    MC_n : integer, optional
+        Not yet implemented.
+    Rayleigh_min : float
+        Minimum conventional Rayleigh criterion for automatic
+        constituent selection; default is 1.
+    robust_kw : {dict, Bunch}
+        Keyword arguments for robust solution method.  Not yet
+        implemented.
+    white : bool
+        If False (default), use band-averaged spectra from the
+        residuals in the confidence limit estimates; if True,
+        assume a white background spectrum.
+
+    Note
+    ----
+    `utide.reconstruct` requires the calculation of confidence intervals.
+
+    Notes
+    -----
+
+    To be added: much additional explanation.
+
+    There will also be more "Other Parameters".
+
+    """
+
+    newopts = _process_opts(opts)
+    compat_opts = _translate_opts(newopts)
+
+    coef = _solv1(t, u, v, lat, **compat_opts)
 
     return coef
 

--- a/utide/_solve.py
+++ b/utide/_solve.py
@@ -239,7 +239,7 @@ def _solv1(tin, uin, vin, lat, **opts):
 
     if opt['conf_int'] is True:
         coef = _confidence(coef, opt, t, e, tin, elor, xraw, xmod,
-                           W, m, B, nc, Xu, Yu, Xv, Yv)
+                           W, m, B, Xu, Yu, Xv, Yv)
 
     # diagnostics
     if not opt['nodiagn']:

--- a/utide/confidence.py
+++ b/utide/confidence.py
@@ -38,17 +38,20 @@ def band_averaged_psd_by_constit(tin, t, e, elor, coef, opt):
         Pvv = np.zeros_like(constits)
         Puv = np.zeros_like(constits)
 
+    print('ba', ba)
+    print('constits', constits)
     for i, (lo, hi) in enumerate(ba.fbnd):
+        print(i, lo, hi)
         inside = (constits >= lo) & (constits <= hi)
         Puu[inside] = ba.Puu[i]
         if opt.twodim:
             Pvv[inside] = ba.Pvv[i]
             Puv[inside] = ba.Puv[i]
-
+    print(Puu, Pvv, Puv)
     return Puu, Pvv, Puv
 
 def _confidence(coef, opt, t, e, tin, elor, xraw, xmod, W, m, B,
-                nc, Xu, Yu, Xv, Yv):
+                Xu, Yu, Xv, Yv):
     """
     This confidence interval calculation does not correspond
     to a single ut_ matlab function, but is based on code
@@ -70,67 +73,57 @@ def _confidence(coef, opt, t, e, tin, elor, xraw, xmod, W, m, B,
     # Make temporaries for quantities needed more than once.
     _Wx = W * xraw
     _WB = W[:, np.newaxis] * B
+
     # Matlab is recalculating xmod here; but we already have it.
     # In the 1-D case xmod is only the real part, but in that
     # case _Wx is real, and we are taking the real part in the
     # end, so the imaginary part would not contribute anything.
     nt = len(xraw)
     nm = B.shape[1]
+
+    # Mean Square Misfit: Eq. 52 (mean squared error)
     varMSM = np.real(np.dot(xraw.conj(), _Wx) -
              np.dot(xmod.conj(), _Wx)) / (nt-nm)
 
-    # gamC = inv(ctranspose(B)*W*B)*varMSM
-
+    # Gamma_C: covariance Eq. 54
     gamC = np.linalg.inv(np.dot(B.conj().T, _WB)) * varMSM
 
-    # gamP = inv(transpose(B)*W*B)*((transpose(xraw)*W*xraw -
-    #            transpose(m)*transpose(B)*W*xraw)/(nt-nm))
 
+    # Gamma_P: pseudo-covariance Eq. 54
     gamP = np.linalg.inv(np.dot(B.T, _WB))
     gamP *= (np.dot(xraw, _Wx) - np.dot(xmod, _Wx)) / (nt - nm)
 
     del _Wx, _WB
 
+    # Eq. 55; convenient intermediate variables; see Eq. 51
     Gall = gamC + gamP
     Hall = gamC - gamP
 
-    coef['g_ci'] = np.nan*np.ones(coef['g'].shape)
-    # import pdb; pdb.set_trace()
+    nc = len(Xu)
+    coef.g_ci = np.nan * np.ones_like(coef.g)
     if opt['twodim']:
-        # FIXME: change to np.ones_like.
-        coef['Lsmaj_ci'] = np.nan * np.ones(coef['g'].shape)
-        coef['Lsmin_ci'] = np.nan * np.ones(coef['g'].shape)
-        coef['theta_ci'] = np.nan * np.ones(coef['g'].shape)
-        # same issue with copying
-        # coef['Lsmaj_ci']= coef['g_ci']
-        # coef['Lsmin_ci']= coef['g_ci']
-        # coef['theta_ci']= coef['g_ci']
-        varcov_mCw = np.nan*np.ones((nc, 4, 4))
+        coef['Lsmaj_ci'] = coef.g_ci.copy()
+        coef['Lsmin_ci'] = coef.g_ci.copy()
+        coef['theta_ci'] = coef.g_ci.copy()
+        varcov_mCw = np.nan * np.ones((nc, 4, 4))
     else:
-        coef['A_ci'] = np.nan*np.ones(coef['g'].shape)
-        # coef['A_ci'] = coef['g_ci']
+        coef['A_ci'] = coef.g_ci.copy()
         varcov_mCw = np.nan * np.ones((nc, 2, 2))
 
     if not opt['white']:
         varcov_mCc = np.copy(varcov_mCw)
-        # varcov_mCc = varcov_mCw
 
-    # for c=1:nc
-    for c in np.arange(nc):
-        # G = [Gall(c,c) Gall(c,c+nc); Gall(c+nc,c) Gall(c+nc,c+nc);];
+    for c in range(nc):
         G = np.array([[Gall[c, c], Gall[c, c+nc]],
                       [Gall[c+nc, c], Gall[c+nc, c+nc]]])
         H = np.array([[Hall[c, c], Hall[c, c+nc]],
                       [Hall[c+nc, c], Hall[c+nc, c+nc]]])
-        # H = [Hall(c,c) Hall(c,c+nc); Hall(c+nc,c) Hall(c+nc,c+nc);];
         varXu = np.real(G[0, 0] + G[1, 1] + 2 * G[0, 1]) / 2
         varYu = np.real(H[0, 0] + H[1, 1] - 2 * H[0, 1]) / 2
 
         if opt['twodim']:
             varXv = np.real(H[0, 0] + H[1, 1] + 2 * H[0, 1]) / 2
             varYv = np.real(G[0, 0] + G[1, 1] - 2 * G[0, 1]) / 2
-            # varXv = real(H(1,1)+H(2,2)+2*H(1,2))/2;
-            # varYv = real(G(1,1)+G(2,2)-2*G(1,2))/2;
 
         if opt['linci']:  # Linearized.
             if not opt['twodim']:
@@ -160,7 +153,6 @@ def _confidence(coef, opt, t, e, tin, elor, xraw, xmod, W, m, B,
                 coef['Lsmin_ci'][c] = 1.96*np.imag(sig1)
                 coef['g_ci'][c] = 1.96*np.real(sig2)
                 coef['theta_ci'][c] = 1.96*np.imag(sig2)
-                # import pdb; pdb.set_trace()
 
         else:  # TODO: Monte Carlo.
             pass

--- a/utide/confidence.py
+++ b/utide/confidence.py
@@ -38,16 +38,12 @@ def band_averaged_psd_by_constit(tin, t, e, elor, coef, opt):
         Pvv = np.zeros_like(constits)
         Puv = np.zeros_like(constits)
 
-    print('ba', ba)
-    print('constits', constits)
     for i, (lo, hi) in enumerate(ba.fbnd):
-        print(i, lo, hi)
         inside = (constits >= lo) & (constits <= hi)
         Puu[inside] = ba.Puu[i]
         if opt.twodim:
             Pvv[inside] = ba.Pvv[i]
             Puv[inside] = ba.Puv[i]
-    print(Puu, Pvv, Puv)
     return Puu, Pvv, Puv
 
 def _confidence(coef, opt, t, e, tin, elor, xraw, xmod, W, m, B,
@@ -64,7 +60,6 @@ def _confidence(coef, opt, t, e, tin, elor, xraw, xmod, W, m, B,
     """
 
     # Confidence Intervals.
-    print('conf. int vls... ')
 
     if not opt['white']:
         Puu, Pvv, Puv = band_averaged_psd_by_constit(tin, t, e, elor,

--- a/utide/constituent_selection.py
+++ b/utide/constituent_selection.py
@@ -76,12 +76,8 @@ def ut_cnstitsel(tref, minres, incnstit, infer):
     cnstit['R'] = []  # Empty because inference is not supported yet.
 
     coef['name'] = cnstit['NR']['name']
-    coef['aux'] = {}
-    coef['aux']['frq'] = cnstit['NR']['frq']
-    coef['aux']['lind'] = cnstit['NR']['lind']
-
-    # another infer if statement
-
-    coef['aux']['reftime'] = tref
+    coef['aux'] = Bunch(frq=cnstit.NR.frq,
+                        lind=cnstit.NR.lind,
+                        reftime=tref)
 
     return nNR, nR, nI, cnstit, coef

--- a/utide/constituent_selection.py
+++ b/utide/constituent_selection.py
@@ -6,6 +6,7 @@ import scipy.io as sio
 from .astronomy import ut_astron
 from . import ut_constants
 from . import constit_index_dict
+from .utilities import Bunch
 
 def ut_cnstitsel(tref, minres, incnstit, infer):
     """
@@ -34,8 +35,8 @@ def ut_cnstitsel(tref, minres, incnstit, infer):
     shallow = ut_constants.shallow
     const = ut_constants.const
 
-    cnstit = {}
-    coef = {}
+    cnstit = Bunch()
+    coef = Bunch()
 
     astro, ader = ut_astron(tref)
 
@@ -49,7 +50,7 @@ def ut_cnstitsel(tref, minres, incnstit, infer):
                                shallow.coef[ik])
 
     # cnstit.NR
-    cnstit['NR'] = {}
+    cnstit['NR'] = Bunch()
 
     # if incnstit.lower() == 'auto':
     if incnstit == 'auto':

--- a/utide/tests/test_solve.py
+++ b/utide/tests/test_solve.py
@@ -34,25 +34,38 @@ def test_roundtrip():
     # Add a tiny bit of noise to prevent division by zero? Didn't do it.
     #time_series += 1e-10 * np.random.randn(len(time_series))
 
-    speed_coef = solve(time, time_series, time_series, lat=lat, cnstit='auto',
-                         notrend=True, rmin=0.95, method='ols',
-                         nodiagn=True, linci=True, conf_int=True)
+#    speed_coef = solve(time, time_series, time_series, lat=lat, cnstit='auto',
+#                         notrend=True, rmin=0.95, method='ols',
+#                         nodiagn=True, linci=True, conf_int=True)
 
-    elev_coef = solve(time, time_series, lat=lat, cnstit='auto',
-                        gwchnone=True, nodsatnone=True, notrend=True,
-                        rmin=0.95, method='ols', nodiagn=True, linci=True,
-                        conf_int=True)
+#    elev_coef = solve(time, time_series, lat=lat, cnstit='auto',
+#                        gwchnone=True, nodsatnone=True, notrend=True,
+#                        rmin=0.95, method='ols', nodiagn=True, linci=True,
+#                        conf_int=True)
+
+    opts = dict(constit='auto',
+                phase='raw',
+                nodal=False,
+                trend=False,
+                method='ols',
+                conf_int='linear',
+                Rayleigh_min=0.95,
+                )
+
+    speed_coef = solve(time, time_series, time_series, lat=lat, **opts)
+    elev_coef = solve(time, time_series, lat=lat, **opts)
 
     amp_err = amp - elev_coef['A'][0]
     phase_err = phase - elev_coef['g'][0]
-    ts_recon, _ = reconstruct(time, elev_coef)
+    ts_recon = reconstruct(time, elev_coef).h
 
-    u, v = reconstruct(time, speed_coef)
+    vel = reconstruct(time, speed_coef)
 
     err = np.sqrt(np.mean((time_series-ts_recon)**2))
 
     print(amp_err, phase_err, err)
     print(elev_coef['aux']['reftime'], tref)
+    print(elev_coef['aux']['opt'])
 
     np.testing.assert_almost_equal(amp_err, 0)
     np.testing.assert_almost_equal(phase_err, 0)


### PR DESCRIPTION
The original Matlab function arguments are not a good match for
Python's more flexible argument handling capabilities, so I have
sketched out a more pythonic interface for solve and reconstruct,
including the docstrings.  Given that some option names needed
to change, I have made changes freely, opting for longer but
more readable names.

I have also started using the Bunch more widely; a subsequent
step will be to switch much of the internal access from dictionary
style to attribute style--which will look more like the original
Matlab.