### PR TITLE
Add the equivalent of the MATLAB option for verbose output.

### DIFF
--- a/utide/_reconstruct.py
+++ b/utide/_reconstruct.py
@@ -18,6 +18,9 @@ def reconstruct(t, coef, **opts):
     epoch : {string, int, `datetime.datetime`}, optional
         Not implemented yet. It will default to the epoch
         used for `coef`.
+    verbose : {True, False}, optional
+        True to enable output message (default). False turns off all
+        messages.
 
     Returns
     -------
@@ -38,10 +41,11 @@ def reconstruct(t, coef, **opts):
 
 def _reconstr1(tin, coef, **opts):
 
-    print('reconstruct:')
-
     # Parse inputs and options.
     t, opt = _rcninit(tin, **opts)
+
+    if opt['RunTimeDisp']:
+        print('reconstruct:', end='')
 
     # Determine constituents to include.
     # if ~isempty(opt.cnstit)
@@ -90,7 +94,8 @@ def _reconstr1(tin, coef, **opts):
               coef['aux']['opt']['gwchlint'],
               coef['aux']['opt']['gwchnone']]
 
-    print('prep/calcs...')
+    if opt['RunTimeDisp']:
+        print('prep/calcs ... ', end='')
 
     E = ut_E(t,
              coef['aux']['reftime'], coef['aux']['frq'][ind],
@@ -124,7 +129,8 @@ def _reconstr1(tin, coef, **opts):
 
         v = []
 
-    print('Done.\n')
+    if opt['RunTimeDisp']:
+        print('done.')
 
     return u, v
 
@@ -140,8 +146,13 @@ def _rcninit(tin, **opts):
     opt['cnstit'] = False
     opt['minsnr'] = 2
     opt['minpe'] = 0
+    opt['RunTimeDisp'] = True
 
     for key, item in opts.items():
+        # Be backward compatible with the MATLAB package syntax.
+        if key == 'verbose':
+            opt['RunTimeDisp'] = item
+
         try:
             opt[key] = item
         except KeyError:

--- a/utide/_solve.py
+++ b/utide/_solve.py
@@ -26,6 +26,7 @@ default_opts = dict(constit='auto',
                     Rayleigh_min=1,
                     robust_kw=dict(weight_function='cauchy'),
                     white=False,
+                    verbose=True
                     )
 
 
@@ -69,6 +70,7 @@ def _translate_opts(opts):
     oldopts.rmin = opts.Rayleigh_min
     oldopts.white = opts.white
     oldopts.newopts = opts  # So we can access new opts via the single "opt."
+    oldopts['RunTimeDisp'] = opts.verbose
     return oldopts
 
 
@@ -128,6 +130,8 @@ def solve(t, u, v=None, lat=None, **opts):
         If False (default), use band-averaged spectra from the
         residuals in the confidence limit estimates; if True,
         assume a white background spectrum.
+    verbose : {True, False}, optional
+        True (default) turns on verbose output. False omits no messages.
 
     Note
     ----
@@ -152,13 +156,14 @@ def solve(t, u, v=None, lat=None, **opts):
 
 def _solv1(tin, uin, vin, lat, **opts):
 
-    print('solve: ')
-
     # The following returns a possibly modified copy of tin (ndarray).
     # t, u, v are fully edited ndarrays (unless v is None).
     packed = _slvinit(tin, uin, vin, lat, **opts)
     tin, t, u, v, tref, lor, elor, opt = packed
     nt = len(t)
+
+    if opt['RunTimeDisp']:
+        print('solve: ', end='')
 
     # opt['cnstit'] = cnstit
     nNR, nR, nI, cnstit, coef = ut_cnstitsel(tref, opt['rmin']/(24*lor),
@@ -170,7 +175,8 @@ def _solv1(tin, uin, vin, lat, **opts):
     coef['aux']['opt'] = opt
     coef['aux']['lat'] = lat
 
-    print('matrix prep ... ')
+    if opt['RunTimeDisp']:
+        print('matrix prep ... ', end='')
 
     ngflgs = [opt['nodsatlint'], opt['nodsatnone'],
               opt['gwchlint'], opt['gwchnone']]
@@ -187,7 +193,8 @@ def _solv1(tin, uin, vin, lat, **opts):
 
     # nm = B.shape[1]  # 2*(nNR + nR) + 1, plus 1 if trend is included.
 
-    print('Solution ...')
+    if opt['RunTimeDisp']:
+        print('solution ... ', end='')
 
     if opt['twodim']:
         xraw = u + 1j*v
@@ -308,7 +315,8 @@ def _solv1(tin, uin, vin, lat, **opts):
     coef['aux']['frq'] = coef['aux']['frq'][ind]
     coef['aux']['lind'] = coef['aux']['lind'][ind]
 
-    print("Done.\n")
+    if opt['RunTimeDisp']:
+        print("done.")
 
     return coef
 

--- a/utide/diagnostics.py
+++ b/utide/diagnostics.py
@@ -5,7 +5,8 @@ import numpy as np
 
 def ut_diagn(coef, opt):
 
-    print('diagnostics...')
+    if opt['RunTimeDisp']:
+        print('diagnostics ... ', end='')
     coef['diagn'] = {}
 
     if opt['twodim']:


### PR DESCRIPTION
Add option to turn off output to screen (defaults to on to maintain existing behaviour). 

I have opted for a more simple `verbose` flag rather than `RunTimeDisp`, although internally the latter is used. At the moment this is a boolean although the MATLAB original code had various levels of control on what was printed to screen.

The option in `utide/_reconstruct.py` is a bit clunky (adding an `if` to check the name of the key), but that means that the function style is consistent in `solve()` and `reconstruct()`.