### PR TITLE
Support arbitrary epoch for time inputs

### DIFF
--- a/doc/strategy.rst
+++ b/doc/strategy.rst
@@ -38,32 +38,35 @@ Public interface
 The package is called `utide`, and presently has a very
 simple interface, with two function: `solve` and
 `reconstruct`.  These are simply English spellings of their
-slightly shortened Matlab counterparts.  Everything else
+Matlab counterparts.  Everything else
 should be considered to be private, regardless of whether it
 has a leading underscore.
 
-There is an overwhelming number of options; we might be able
-to find ways of making this interface friendlier.
+There is an overwhelming number of options, and many of the
+Matlab names are rather cryptic.  We have made some changes
+in the way options are specified, but the process is not
+complete.
 
-Options are being held internally in a `dict`.  We will
-switch to using a `Bunch` so as to provide both dictionary
-and attribute access syntax.
+Options are being held internally in a `Bunch` so as to
+provide both dictionary and attribute access syntax.
 
 Time
 ^^^^
-Presently, time inputs are assumed to be Matlab `datenum`
-arrays.  We need to make this more flexible, at the very
-least including the ability to handle time in days since a
-specified epoch. An array of Python datetime objects could
-be supported, but this is not top priority. At some point
-we will presumably handle the numpy datetime64 dtype, but we
-can wait until it has been reworked and is no longer in a
-semi-broken experimental state.  We will also need to
-investigate handling whatever Pandas produces.
+Time inputs are arrays of time in days relative to the epoch
+given in the `epoch` keyword argument.  In the Matlab version
+of utide these would be Matlab datenums; in the python version,
+using Matlab datenums requires `epoch = 'matlab'`.  The default is
+`epoch = 'python'`, corresponding to the `matplotlib` date
+numbers.  Any other epoch can be specified using either a
+string, like `'2015-01-01'`, or a Python standard library
+`datetime.datetime` or `datetime.date` instance.  The numpy
+`datetime64` dtype is not yet supported, nor are any Pandas
+constructs.
 
 Missing values
 ^^^^^^^^^^^^^^^
-The `t`, `u`, `v` inputs to `solve` now support any combination
+The `t`, `u`, `v` inputs to `solve` and the `t` input to `
+reconstruct` now support any combination
 of nans and masked array inputs to indicate missing values.
 
 The degree to which masked arrays will be used internally is

--- a/tests/test_astron.py
+++ b/tests/test_astron.py
@@ -17,7 +17,9 @@ from utide.astronomy import ut_astron
 
 
 def test_astron():
-    dns = [694086.000000000, 736094.552430556]
+    # Switch from Matlab epoch to python epoch.
+    dns = [t - 366 for t in [694086.000000000, 736094.552430556]]
+
     a_expected = np.array([[-0.190238223090586, -0.181487296022524],
                            [0.308043143259513, 0.867328798490917],
                            [0.117804920168928, 0.133410946894728],

--- a/tests/test_harmonics.py
+++ b/tests/test_harmonics.py
@@ -21,6 +21,10 @@ fname = os.path.join(_base_dir, 'FUV0.npz')
 
 def test_FUV():
     x = loadbunch(fname, masked=False)
+    # Switch epoch from Matlab to Python
+    x.t -= 366
+    x.t0 -= 366
+
     for i, flag in enumerate(x.flags):
         F, U, V = FUV(x.t, x.t0, x.lind-1, x.lat, flag)
         print('i:', i, "ngflgs:", flag)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,20 @@
+from __future__ import (absolute_import, division, print_function)
+
+import datetime
+
+import numpy as np
+from utide._time_conversion import _normalize_time
+
+
+def test_formats():
+    forms = [(np.array([693595.1]), 'python'),
+             (np.array([693961.1]), 'matlab'),
+             (np.array([2.1]), datetime.date(1899, 12, 29)),
+             (np.array([3.1]), datetime.datetime(1899, 12, 28)),
+             (np.array([2.6]), datetime.datetime(1899, 12, 28, 12)),
+             (np.array([2.1]), '1899-12-29')]
+
+    expected = _normalize_time(*forms[0])
+
+    for form in forms[1:]:
+        np.testing.assert_almost_equal(_normalize_time(*form), expected)

--- a/tests/test_uv.py
+++ b/tests/test_uv.py
@@ -32,6 +32,7 @@ def fake_tide(t, M2amp, M2phase):
 @pytest.fixture
 def make_data():
     N = 500
+    np.random.seed(1234)
     t = date_range(start='2016-03-29', periods=N, freq='H')
     # Signal + some noise.
     u = fake_tide(np.arange(N), M2amp=2, M2phase=0) + np.random.randn(N)

--- a/utide/_time_conversion.py
+++ b/utide/_time_conversion.py
@@ -1,0 +1,39 @@
+"""
+Utility for allowing flexible time input.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+import warnings
+from datetime import date, datetime
+
+try:
+    from datetime import timezone
+    have_tz = True
+except ImportError:
+    have_tz = False
+
+
+def _normalize_time(t, epoch):
+    if epoch == 'python':
+        return t
+    if epoch == 'matlab':
+        return t - 366
+    try:
+        epoch = datetime.strptime(epoch, "%Y-%m-%d")
+    except (TypeError, ValueError):
+        pass
+    if isinstance(epoch, date):
+        if not hasattr(epoch, 'time'):
+            return t + epoch.toordinal()
+        # It must be a datetime, which is also an instance of date.
+        if epoch.tzinfo is not None:
+            if have_tz:
+                epoch = epoch.astimezone(timezone.utc)
+            else:
+                warnings.warn("Timezone info in epoch is being ignored;"
+                              " UTC is assumed.")
+        ofs = (epoch.toordinal() + epoch.hour / 24 +
+               epoch.minute / 1440 + epoch.second / 86400)
+        return t + ofs
+    raise ValueError("Cannot parse epoch as string or date or datetime")

--- a/utide/astronomy.py
+++ b/utide/astronomy.py
@@ -21,7 +21,9 @@ def ut_astron(jd):
     Parameters
     ----------
     jd : float, scalar or sequence
-        Time (UTC) in days since the Matlab datenum epoch.
+        Time (UTC) in days starting with 1 on 1 Jan. of the year 1
+        in the proleptic Gregorian calendar as in
+        `datetime.date.toordinal`.
 
     Returns
     -------
@@ -56,8 +58,10 @@ def ut_astron(jd):
 
     jd = np.atleast_1d(jd).flatten()
 
-    # datenum(1899,12,31,12,0,0)
-    daten = 693961.500000000
+    # Shift epoch to 1899-12-31 at noon:
+    # daten = 693961.500000000  Matlab datenum version
+
+    daten = 693595.5  # Python epoch is 366 days later than Matlab's
 
     d = jd - daten
     D = d / 10000

--- a/utide/confidence.py
+++ b/utide/confidence.py
@@ -134,7 +134,8 @@ def nearestSPD(A):
         # Tweaking strategy differs from D'Errico version.  It
         # is still a very small adjustment, but much larger than
         # his.
-        maxeig = np.linalg.eigvals(Ahat).max()
+        # Eigvals are or can be complex dtype, so take abs().
+        maxeig = np.abs(np.linalg.eigvals(Ahat)).max()
         Ahat[np.diag_indices(n)] += np.spacing(maxeig)
         # Normally no more than one adjustment will be needed.
         if k > 100:

--- a/utide/constituent_selection.py
+++ b/utide/constituent_selection.py
@@ -41,7 +41,7 @@ def ut_cnstitsel(tref, minres, incnstit, infer):
     astro, ader = ut_astron(tref)
 
     ii = np.isfinite(const.ishallow)
-    const.freq[~ii] = np.dot(const.doodson[~ii, :], ader) / 24
+    const.freq[~ii] = np.dot(const.doodson[~ii, :], ader[:, 0]) / 24
 
     for k in ii.nonzero()[0]:
         ik = const.ishallow[k]+np.arange(const.nshallow[k])


### PR DESCRIPTION
Prior to this, time was assumed to be in the form of Matlab
datenums--but this is not what any typical Python code would
work with.  Now the default is matplotlib date numbers, and
any epoch can be specified.