### PR TITLE
Add Python 3.6 to Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
     env: TEST_TARGET=default
   - python: 3.5
     env: TEST_TARGET=coding_standards
+  - python: 3.6
+    env: TEST_TARGET=default
   allow_failures:
   - python: 3.5
     env: TEST_TARGET=coding_standards


### PR DESCRIPTION
I am unsure if this will work, but it would be nice if it did.