### PR TITLE
fix pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ matrix:
     env: TEST_TARGET=default
   - python: 3.5
     env: TEST_TARGET=default
-  - python: 3.5
-    env: TEST_TARGET=coding_standards
   - python: 3.6
     env: TEST_TARGET=default
-  allow_failures:
   - python: 3.5
+    env: TEST_TARGET=coding_standards
+  allow_failures:
+  - python: 3.6
     env: TEST_TARGET=coding_standards
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 import os
-import sys
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
 
 import versioneer
 

--- a/tests/test_harmonics.py
+++ b/tests/test_harmonics.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_array_almost_equal
 
 from utide.harmonics import FUV
 from utide.utilities import loadbunch
-from utide import _base_dir
+from utide._ut_constants import _base_dir
 
 fname = os.path.join(_base_dir, 'FUV0.npz')
 

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -11,9 +11,10 @@ from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 
-from utide import ut_constants
+from utide._ut_constants import ut_constants
 from utide import solve
 from utide import reconstruct
+from utide.utilities import Bunch
 
 
 def test_roundtrip():
@@ -63,7 +64,8 @@ def test_roundtrip():
     htmp = reconstruct(time, elev_coef, min_PE=10)
     vel = reconstruct(time, speed_coef, min_SNR=0)
     htmp = reconstruct(time, elev_coef, min_SNR=0)
-
+    assert isinstance(vel, Bunch)
+    assert isinstance(htmp, Bunch)
 
     # Now the round-trip check, just for the elevation.
     err = np.sqrt(np.mean((time_series-ts_recon)**2))
@@ -119,10 +121,14 @@ def test_masked_input():
     amp_err = amp - elev_coef['A'][0]
     phase_err = phase - elev_coef['g'][0]
     ts_recon = reconstruct(time, elev_coef).h
+    assert isinstance(ts_recon, np.ndarray)
 
     # pure smoke testing of reconstruct
     vel = reconstruct(time, speed_coef)
+    assert isinstance(vel, Bunch)
+
     elev = reconstruct(time, elev_coef)
+    assert isinstance(elev, Bunch)
 
     np.testing.assert_almost_equal(amp_err, 0)
     np.testing.assert_almost_equal(phase_err, 0)

--- a/utide/__init__.py
+++ b/utide/__init__.py
@@ -1,22 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 
-import os
-
-from utide.utilities import loadbunch, convert_unicode_arrays
-
-_base_dir = os.path.join(os.path.dirname(__file__), 'data')
-_ut_constants_fname = os.path.join(_base_dir, 'ut_constants.npz')
-
-# At least for now, use NaNs rather than masked arrays.
-ut_constants = loadbunch(_ut_constants_fname, masked=False)
-ut_constants = convert_unicode_arrays(ut_constants)
-
-constit_names = list(ut_constants.const.name)
-
-# Make a dictionary for index lookups.
-constit_index_dict = dict([(name, i) for (i, name) in
-                           enumerate(constit_names)])
-
 from ._solve import solve
 from ._reconstruct import reconstruct
 

--- a/utide/__init__.py
+++ b/utide/__init__.py
@@ -2,9 +2,12 @@ from __future__ import (absolute_import, division, print_function)
 
 from ._solve import solve
 from ._reconstruct import reconstruct
+from ._ut_constants import ut_constants, constit_index_dict
 
 __all__ = ['solve',
-           'reconstruct']
+           'reconstruct',
+           'ut_constants',
+           'constit_index_dict']
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/utide/_solve.py
+++ b/utide/_solve.py
@@ -12,7 +12,7 @@ from .ellipse_params import ut_cs2cep
 from .constituent_selection import ut_cnstitsel
 from .confidence import _confidence
 from .utilities import Bunch
-from . import constit_index_dict
+from ._ut_constants import constit_index_dict
 from .robustfit import robustfit
 from ._time_conversion import _normalize_time
 

--- a/utide/_ut_constants.py
+++ b/utide/_ut_constants.py
@@ -1,0 +1,19 @@
+from __future__ import (absolute_import, division, print_function)
+
+import os
+
+from .utilities import convert_unicode_arrays, loadbunch
+
+
+_base_dir = os.path.join(os.path.dirname(__file__), 'data')
+_ut_constants_fname = os.path.join(_base_dir, 'ut_constants.npz')
+
+# At least for now, use NaNs rather than masked arrays.
+ut_constants = loadbunch(_ut_constants_fname, masked=False)
+ut_constants = convert_unicode_arrays(ut_constants)
+
+constit_names = list(ut_constants.const.name)
+
+# Make a dictionary for index lookups.
+constit_index_dict = dict([(name, i) for (i, name) in
+                           enumerate(constit_names)])

--- a/utide/constituent_selection.py
+++ b/utide/constituent_selection.py
@@ -5,8 +5,7 @@ from collections import OrderedDict
 import numpy as np
 
 from .astronomy import ut_astron
-from . import ut_constants
-from . import constit_index_dict
+from ._ut_constants import ut_constants, constit_index_dict
 from .utilities import Bunch
 
 

--- a/utide/harmonics.py
+++ b/utide/harmonics.py
@@ -7,8 +7,8 @@ from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 
-from utide.astronomy import ut_astron
-from utide import ut_constants
+from .astronomy import ut_astron
+from ._ut_constants import ut_constants
 
 
 sat = ut_constants.sat


### PR DESCRIPTION
@wesleybowman I would wait for @efiring input on this small re-factor b/c he may be on the side of just ignoring the pep8 import failure and keep `ut_constants` in `__init__` instead.