### PR TITLE
Include more information in the return from reconstruct().

### DIFF
--- a/notebooks/utide_real_data_example.ipynb
+++ b/notebooks/utide_real_data_example.ipynb
@@ -2,256 +2,218 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1.0\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
+    "%matplotlib notebook\n",
+    "\n",
+    "import datetime\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.dates as mdates\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
     "import utide\n",
     "\n",
     "print(utide.__version__)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>elev</th>\n",
-       "      <th>flag</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>datetime</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>1998-01-01 00:00:00</th>\n",
-       "      <td>1.20</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1998-01-01 01:00:00</th>\n",
-       "      <td>1.43</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1998-01-01 02:00:00</th>\n",
-       "      <td>1.73</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1998-01-01 03:00:00</th>\n",
-       "      <td>2.03</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1998-01-01 04:00:00</th>\n",
-       "      <td>2.38</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1998-01-01 05:00:00</th>\n",
-       "      <td>2.54</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                     elev  flag\n",
-       "datetime                       \n",
-       "1998-01-01 00:00:00  1.20     0\n",
-       "1998-01-01 01:00:00  1.43     0\n",
-       "1998-01-01 02:00:00  1.73     0\n",
-       "1998-01-01 03:00:00  2.03     0\n",
-       "1998-01-01 04:00:00  2.38     0\n",
-       "1998-01-01 05:00:00  2.54     0"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "from datetime import datetime\n",
-    "from pandas import read_table, DataFrame\n",
+    "Look at the data file to see what structure it has."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('can1998.dtf') as f:\n",
+    "    lines = f.readlines()\n",
+    "print(''.join(lines[:30]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It looks like the fields are seconds, year, month, day, hour, elevation, flag.  We need a date parser function to combine the date and time fields into a single value to be used as the datetime index."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "\n",
-    "def date_parser(year, day, month, hour):\n",
-    "    year, day, month, hour = map(int, (year, day, month, hour))\n",
-    "    return datetime(year, day, month, hour)\n",
+    "def date_parser(year, month, day, hour):\n",
+    "    year, month, day, hour = map(int, (year, month, day, hour))\n",
+    "    return datetime.datetime(year, month, day, hour)\n",
     "\n",
+    "# Names of the columns that will be used to make a \"datetime\" column:\n",
     "parse_dates = dict(datetime=['year', 'month', 'day','hour'])\n",
     "\n",
+    "# Names of the original columns in the file, including only\n",
+    "# the ones we will use; we are skipping the first, which appears\n",
+    "# to be seconds from the beginning.\n",
     "names = ['year', 'month', 'day', 'hour', 'elev', 'flag']\n",
     "\n",
-    "obs = read_table('can1998.dtf',\n",
-    "                 names=names,\n",
-    "                 skipinitialspace=True,\n",
-    "                 delim_whitespace=True,\n",
-    "                 index_col='datetime',\n",
-    "                 usecols=range(1, 7),\n",
-    "                 na_values='9.990',\n",
-    "                 parse_dates=parse_dates,\n",
-    "                 date_parser=date_parser)\n",
+    "obs = pd.read_table('can1998.dtf',\n",
+    "                    names=names,\n",
+    "                    skipinitialspace=True,\n",
+    "                    delim_whitespace=True,\n",
+    "                    index_col='datetime',\n",
+    "                    usecols=range(1, 7),\n",
+    "                    na_values='9.990',\n",
+    "                    parse_dates=parse_dates,\n",
+    "                    date_parser=date_parser,\n",
+    "                   )\n",
     "obs.head(6)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Although there are no elevations marked bad via special value, which should be `nan` after reading the file, the flag value of 2 indicates the values are unreliable, so we will mark them with `nan`, calculate the deviations of the elevations from their mean (stored in a new column called \"anomaly\"), and then interpolate to fill in the `nan` values in the anomaly."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
     "bad = obs['flag'] == 2\n",
     "corrected = obs['flag'] == 1\n",
     "\n",
-    "obs[bad] = np.NaN\n",
+    "obs.loc[bad, 'elev'] = np.nan\n",
     "obs['anomaly'] = obs['elev'] - obs['elev'].mean()\n",
-    "obs['anomaly'] = obs['anomaly'].interpolate()"
+    "obs['anomaly'] = obs['anomaly'].interpolate()\n",
+    "print('{} points were flagged \"bad\" and interpolated'.format(bad.sum()))\n",
+    "print('{} points were flagged \"corrected\" and left unchanged'.format(corrected.sum()))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The utide package works with ordinary numpy arrays, not with Pandas Series or Dataframes, so we need to make a `time` variable in floating point days since a given epoch, and use the `values` attribute of the elevation anomaly (a Pandas Series) to extract the underlying numpy ndarray."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "solve: \n",
-      "matrix prep ... \n",
-      "Solution ...\n",
-      "diagnostics...\n",
-      "Done.\n",
-      "\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "from utide import solve\n",
-    "from matplotlib.dates import date2num\n",
+    "time = mdates.date2num(obs.index.to_pydatetime())\n",
     "\n",
-    "time = date2num(obs.index.to_pydatetime())\n",
-    "\n",
-    "coef = solve(time, obs['anomaly'].values,\n",
-    "             lat=-25,\n",
-    "             method='ols',\n",
-    "             conf_int='linear')"
+    "coef = utide.solve(time, obs['anomaly'].values,\n",
+    "                   lat=-25,\n",
+    "                   method='ols',\n",
+    "                   conf_int='MC')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The amplitudes and phases from the fit are now in the `coef` data structure (a Bunch), which can be used directly in the `reconstruct` function to generate a hindcast or forecast of the tides at the times specified in the `time` array."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "reconstruct:\n",
-      "prep/calcs...\n",
-      "Done.\n",
-      "\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "from utide import reconstruct\n",
-    "\n",
-    "tide = reconstruct(time, coef)"
+    "print(coef.keys())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAwMAAAE7CAYAAACBlF3KAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzsnXecFLX7xz8BpKMIIggIKB1EOlipIkUEaVJUkJ8FCxas\nKPrlQLBhoQiKCgooItKbCkgTFUGK9IODo/dytKvc5ffHc+POzs7stMzssZv365XX7s5k8yQzmUye\n5MkTxjmHRCKRSCQSiUQiiT1yRToDEolEIpFIJBKJJDJIZUAikUgkEolEIolRpDIgkUgkEolEIpHE\nKFIZkEgkEolEIpFIYhSpDEgkEolEIpFIJDGKVAYkEolEIpFIJJIYRYgywBibwBg7zhjbbHC+KWMs\niTG2ITu8JUKuRCKRSCQSiUQicU4eQel8A2AMgMlh4qzinHcQJE8ikUgkEolEIpG4RMjMAOd8NYCz\nJtGYCFkSiUQikUgkEolEDH6uGbidMbaJMbaQMVbDR7kSiUQikUgkEolEB1FmQmasB1COc57MGGsL\nYA6AKj7JlkgkEolEIpFIJDr4ogxwzi+qvv/MGBvHGCvGOT8T7n+MMe597iQSiUQikUgkkuiGc65r\nsi9SGWAwWBfAGCvJOT+e/b0RAGamCChwHlv6AGMsqssc7eXTI9bKHGvlVYilcsdSWdXIckc/sVRW\nNbFU7lgqqxrGjJfuClEGGGNTATQDUJwxdgDAYAB5AXDO+ZcAujLGngaQASAFQHcRciWSSLF/P1Cy\nJJA/f6RzIpFIJBKJROIclpO1I8YYz8n584Jo11ijoXwnTpAiUKcOsHGjefxoKLMdYq28CrFU7lgq\nqxpZ7ugnlsqqJpbKHUtlVZNdbt3pAbkDcQ5j8ODBkc6Cp0RD+Q4epM9Nm4ANG8zjR0OZ7RBr5VWI\npXLHUlnVyHJHP7FUVjWxVO5YKqtV5MyARGKTDRuA+vUDv2UVlUgkEolEkpORMwMxDudASkqkcxE9\nhFmDI5FIJBKJRHJFIZWBGGDsWKBgQeCvvyKdk+ggEsoA53T/0tL8ly2RSCQSiSR6kcpADDB0KH1+\n+21EsxEVZGUBL7wQfGzRIu/lTp8O3HEH8PTT3suSSCQSiUQSOwhRBhhjExhjxxljm8PEGc0Y280Y\n28QYqyNCriQ8Fy4A8+ZJsxaRrFkDrFoVfOy++7yXq8zqzJzpvSyJRCKRSCSxg6iZgW8AtDY6yRhr\nC6Ai57wygH4AvhAkVxKG3r2Bjh3JFSYArF0rF7u6JdJmOlKxk0gkEokkOkhLA95/Hzh7NrL5EKIM\ncM5XAwhXlI4AJmfH/RvANYyxkiJkS4xZvDj496ZNwPz5kcmLl7RoATRt6o8s2RmXRCOckwnarFn+\nyFu9mp4l7SybRAznzkW+c+ElWVnA5MnA+fORzolE4o6XXwbeeCPU/Nhv/FozUAbAQdXvw9nHJB6i\n13Ht2BE4c8b/vHjJ8uXUqZg2zXtZuSK0ykbO6Ei85NAh4IsvgC5d/JGnuPl+/XV/5MUaRYsCxYr5\nK/PPP4FTp/yRNWIE0KcP0K+fP/LCcelSpHMguZLZvZs+p0wJ7GEUCXL8AmLG2H8hLi4u0tmJCt56\nK9I58IaePb2XESlPQspOx3JmInLMmEHrQzIy/JN54ADQowfwv/95K2fTJm/T15I3L32eOAE0by5n\nCK5ktmyhcOedwC23eC/v9Glg4ED6bmUHeC+ZNw8oXBiYNCmy+YhGEhKA48cjnQvvUQ8w9ukjNu24\nuLigPnQ48ogVbchhADeqfpfNPmaK3HTMOUb3PtpmBvzE6szABx+QO9fnnnMvc+JE4Pff6XtSEk2R\nR2qGIpbp1o0+16wB7r7be3nnzgHlywd+K17BRJOQAHTo4E3aRuTOTZ9791Jo2lTOfl2JHDwI3Hpr\n4LcfnbexYwPfI9UO7tkDvPkmsHMn/R43TnxHLhIkJdGzWaRIpHMCVK5Mn9HeLqj7aUeOiE07Li4u\naBA9nEIg8lFi2UGPeQB6Z2fmNgBJnPMY0Pkii9F9j+bRZbWZw4ABwL33ikv7wgXgrrvCxxk9Gpg7\nl0aunn9ejFzt2o9PPxWTrlV++w2oUIE6bbEI50BqauC3X89P0aL+yFGmqf1EKrPRwaFD/su8fNl/\nmVp69yZ3z5uz/SfmyxfZ/Iji2muBq6+OdC5iC/X7JDMz9Pzp06QY/fijs/SHDwcaN6ZBxHCIci06\nFcCfAKowxg4wxvoyxvoxxp4EAM75IgCJjLEEAOMBPCNCrpazZ4H33qMRtSsBxfzDKw81kVYGNm4E\nxo+n7/v2AR9+qF/Z3fDzz8G/1QsgR44EliwRt5Zg6VLjc1u30ucLLwAPPCBGnhHqkTE/6NED2L+f\n7HRjkdatgQIFAr8jpUxz7s0oWSQ6V5FQBqJ9hFHhjTciK//rr4F//vEu/ZxwH71euPz338A333gr\nIxxHj5KJYizBOTBqFLBjh79yzdrCWbNo9rZHD2fpv/UWeZI0W88jxEyIc97LQpz+ImSF4+WX6QHa\ns4caJCssXgzcfDNQqZK3eTOS3aYN0KsX8P337tPLyqJp2htuCB/vhx/I9CR/fvcyjUhIAOrVo+9t\n2gDVqpHSkycP8NJL4uS0a2cep2dP5w+SmkKFjM/VquWdUqdVoPzqSGVlAYcPAykp9HvPHprGLF3a\nH/l+c+kSrQfQjsgvWRKZ/Ghp2ZLuR3y82HSPHhWbnhX8qsOcU/kWLwb69gW2bweqV/dHdqR4//3A\n96Qkb2eY9DrmTzwRfG7VKnrXNGrkXt7mzcCwYaHyDx+mwZp27YASJdzLscuhQ5QXUQMFt91Gn3ny\nAI88IiZNOyhtfKQUL7NRbLccOUL9JPX9WrsWePFF+u5nudXtb0ICWSCozbQKFhQjx0yBjarJWmXK\nUhmlNePgQRr1Ux48v1FGT6ZOFZPek0/SQ7x+Pf0O1zCNHClGphGKvR8A3HNPoKP88sviVsx73WBo\nMWvo1bazItE2TH6NTD/7LFCuXMBbxpIlQJky1hbLrVjhnWeR2bOBihUD+2eIonBhmiY3w4/rn54e\nemz5cmDXLmv/T0wEatcGNmwIH+/o0ch4ZFHWDHjN669Tne3bl35/950/chX27wfWrfNXphor9dlr\nmjYlMwURaAf5du4E6tcHypYFHn3Unw0ggdA2OTGRFNy//xYrp3fv2DTPVM9Win7PL11KbYLWk9nF\ni8b/WbvWm5mSGTMC/TWFZ58N/i3qfROufECUKQOKhwqr096KOdHp02Tn7Teip6MmTKDPlSvNvYP4\n2cAkJAT/3r5dTLp2TI5ELOQ1Q/SILUAvHe31Skjwx6PNFwZbA86YEfz75EmgVStqMAF6QTdvDjRo\n4E2+Onem+ut2Nu3HH/W92AwbBjz+uLu07cI5jQAqnR03NshLltBs5+bN1EEKx759zuU4JT4+tA4B\n5JFGNFrTNqMXK+c0iCR6RLBCBRoRN0s3PR34919vRiS1nQs9pkwBune31/FKTgbatnWeL1GoFd5I\nKl4A8Mwz9O510z4nJQX/7tXLXr1wUof69QPGjLH/P69QtwV16ohN+9df6XPECBqoXLuW5OnV/cce\nAz77jJRZtTMHEaxdG3BKoWbNGrFyFEzrJOc8xwbKnnU6diSr2tKlOX/oIc537Qoff8sWxQqXgll8\nUaSlcf7II8GyRaBOzyw884wYmXqkpoaX3aMH51lZ7uUkJ+unzznno0aFHn/vPXfyliyxd41F3NdJ\nk/TTffZZ92mHY9064zK1bx8cd+BAOn711fR78WKx9Tozk/PjxwO/lbR79uS8d2/OU1JC/3PkiHkd\nU9I5d47zixdDy5mezvnJk6HH//xTTLnUHDgQSH/IEHd16sYbA3Hr1w8fd/360PQPHhRTJiMeesi4\nbKdOiZWlTf+tt/TjjR9P50eM8Eb+/v3h4/3f/1G8+fPtpf/rr/QeU/jiC2d1xsk7cMoUa/VUZFvQ\nv7/3bW44srI437bNPA9PPeVcRvHioemp279wjBlD8Y8csSczEtfSiIMHvc3HK6/ol7VEiWB5mZli\n85GVxfnRo4HfpUvr56NcueD/ff+9O/nq91Z2nxp6IapmBpSp5yNHaNSwa9fwdtzaUaIqVbzLmzof\nI0fSSIzReT8YN867hdZm5jLTpgFz5jhPf+tWMjUymhlIS9Pfze+NN5yP2GRlidmfISsr2DONGUb2\n6pMnu8+LEXPnAg0bWoublhYYUVHqMOdi89O9O1CyJI2krFgROP7DD3Qdvv02OP706WQuN2qUtfSv\nuYZMhLQ0aOCP/fHly2SOpaBsyGXEvHlUdiOsmuGlpemPlN94I/D224HfGRliF/6HM+/q1InMoZKS\nvGkTjdYqKI4I3PqLz8oKtDHq56B8ebIFNkIxX/rrL3vyWrem9UoKTz0VPv6wYXTPu3fXP69nnnal\n4dXOyykp9A6pWdM8rhvT39OnQ49ZvS/KDPi8edblhXsfLVlC6wuzsigPnAeeS6/MdE+e9CZdO3LT\n0sQ7Vhg6lNYpLFwYPp72/SnKTMisPDleGVi+nGyErZBHsxx682ZauPTee/rxRXdajJg5k/Ixcyb9\n1jMn8dvPN+B+I6OjR/UXH1qxa3ZjKlSrFnWeXn1V/3y4hdFOH/BFi8TYgz70EHmmMbPfUzCyrbaj\nUNjFqjekAwfoWn/4If3OzCRFNzHRnjyz51AxKWncmMyPtGhf/oqi5LZjp7gN1CLaI5Zd85iOHcl0\nQA9tJ8ToRbJ3L927N9/UPz9sWOC+FCgA1KhhL49GTJ8efkH2778DLVrQmpD8+cV7xvHaw1rNmoH2\np2nT4HPhOjlO3kXq/8ydSy6AzVCUvOnTA6aif/5pXzZgbRG46HeslfS0110Eo0fToMEHH1iLL7qj\nbKXNUXtwsqpIZ2SQ/bwR995LpjJ33UWmi23bUv3u3p3eTV4oj9p+nGis1KH8+amdFcm4cfTZvj05\nenHiRGHsWOfmyA8/HP68KNeibRhjOxljuxhjIRvMM8aaMsaSGGMbsoPlMdYWLchG2ApGlUj7wsvK\nAp5+2j8vIaNH06dik6esbVCzeDHZjD72mPhFSEZoFxfa3YysdGkK6tFaPzGyaQ+H046c08Wq7dqR\nbeL48cDHHwfcnIq0tb10iWzD//1XXJrhUDpOWnv7y5dpbwf16KTZJkQ9e5J9uxGKfWc4tm+nDX/W\nraNF9MoIbLiXipuX9bJltPhMxAv/3LmA1y276L3U3nnH2n9Xr6bPX34xjlOuHNWrzEzrC5fN+Phj\na/GUtkjtGccKu3eHH3nbsoXqipEyvnWru5HlnTupXpQsGdgoUOHllwP3bNkysi9fswb4v/9zNmOp\nbsseeIDsn+1QsSKl0bKlfprh4Fx/3YeaAQPEtklHjlhzq7xli7Ei74R162im2c49Eq0MWEnPyZ46\nJUpYe+8rM1ZKezx9On2K3iQL0G+T4uLEOVpxkw83qAccjAaozejfnzwzOsF0AbSR/ZDVAFIoEgCU\nB3AVgE0AqmniNAUwz0HaQbZSZjbAvXsb276tWMH52bOcL1/O+bJlxvF+/pnsd9evD7Wd3b6dzoXj\nwgWySatcmfOJEzn/6KPg9Hfs8M7u0SxNvTBtGtnC//AD/Z4yxZm8rl3t5WPQIJKbmWmvjHp2fHZC\nUpI9eQoTJ7qT6/QeP/qo8f+TkynOyJH0u3Dh0P//8QfZvdvBLN933835q69y/v775nF79Qq2kzSS\nZfRsu7m++fLpp7l2LecLFri/f8uX27uueqjXCtgNGRmh6VWpEhynTh16zlJTqS4odebHH72pr2bU\nr++tXOU/O3dy/vvvxmm+807w/x54IHBu4EDn5TMrS2Ji+HhvvmldVlqa9WuotLPa46dOBf9ev96a\n7NWrvbuPFy9yvnQptQlpaRRWruS8b1/rspT1SyJw8mwWKCBW3scfc/7XX8b/mTs3OP6oUeZy/v7b\nedujhL17nZdTD721W+rw7bec//STOxlGawZEt0VaSpUKpPP008Fru9ThxhuD/6f0zezm48gRetcF\n/xecc4P+ttEJqwHAbQB+Vv0eCOB1TZymAOY7SPu/QjRrRgtrwqEswjILefPav/nlypnfiHBKhh+V\nToTcevWcy3OSj8mT7ZUxPd1d+RITAy9kO3z7rbh7a+ceh3sBPvooxXnvvcCxDh1oUSHnnO/bR8dK\nl9ZPOymJlLInngg+LrqcBQsal0+Jk54eem7GDPHX+NIlceVauND8/u3eTR3x+PhAR1xNYqJz+amp\noelVq6Yft2RJ+uzRgxaAP/WUN/XVjLp1vZVrNc3nngv+n1oZ6N/fefnM5O7YET6eHWXAyIGCXlAU\nR+3xI0eCf//9tzXZ8+Z5dx+7d6f4jz1Gn7VqOXs+rHLiBOeHDumfW7HCmexwbZ4Z4dI1GljRxhs9\nOryMc+eclUsbEhKcl1OP06fF3NvZs2mAUjtgkppqr//ntE7pccMNgXTuust7ZSB/fr30wTn3bgFx\nGQDqJWuHso9puZ0xtokxtpAxZtsCdcUKWlgTbrrMqq2ZEzs3Kz5mW7Swn64RZ87470cfALZtow0v\nnJj+zJpl3/Z240Z78d3aa990EwW76URix1Qg/PX89ls6r75X8+bRokIgYKJjNJV74420VflXXwWe\niYkT3eY4lOTk0GNPPRVctiefBK67jtZCKK71unZ1L5vz4N8iF4WZ1fUVK2i/jfz5gapV9c043OzF\nsHkzramykielLkybBixY4MzEzohdu8jMMRyzZ9MztG2b/fQLFgzeaEqPxx4Tt3Hk8eOh9caMZs2C\nzW2MOHQovE37u++au4XOzKT1M6+9Zj1/Ru2d9rjVdtHJPhEdOtCePp06hY+nmHkprrK9cDmr5vrr\naZ8CgNoHtZlYs2bO0vRqLxK7prxG6C1SdoLI9jQ5GShe3FrcDRvCr3Xp1InM2LRuOt99NzKL5OfM\nCV5fuXq1saOHgwep/gwZQn1axbTYLrbXFRppCVYDgC4AvlT9fhjAaE2cwgAKZn9vC2CXxbR5cBis\nO4Ko8MwzYrRddZg4kfM5c6xpZaJlt21rTQP0Qn716uFlTZsmRs7LL1svX3y8NbduVoLeqCrn5AJw\n4ECarlTz9NPi7+/nn5uX2epslzZwzvk//4Svs+r4Z8+GHhMZwslWB2Uq1Y4JRLgQHx8s98wZcWUy\nmxl4553w+UlKEn9ta9b07h5mZOibcynnjZ4pJyYlVuqQlfpkFJSZgW3byKRDe37gQDInsOJqc+pU\nsdf53nvDy7M6eqoOmzbpX6cyZYJ/r1oVLEvPjDMzk/MmTcTfy23b6JoXLOh9fVGjxFe7RL7qKs7/\n9z/nsvVMNu3mRy906xZ8T7KyKGjjmc0MGLmsthu2bnVeTi1OzJb02L07cP7nnwPHz551X97ffrNX\nJqW/qp4V8KtuU9zBXNuP5txbM6FfVL9DzIR0/pMIoJiFtEMugt5Uu8Jzz4m94HZvhJ+y1KSkcL5x\no1i5deqElylKziuvWCujXoPnJmg7+wp33EHnBwyg35mZzkwqrAYjO9CsLFqjYsdOVh1WrQqe4ja7\nh4cPi72vRvX42DGy5zaLf/iwGLmFCgWX+cQJcWVSlIH16znv0oWm3tW8+27of0qVCpxPSBCTD6WD\nnpys37EVFYoW1TcjVM6vXatfz9S2siLqkFldthIUU6B77w0fr0WL8HIPHRJ/ncuXDy9Tb+8LK+H5\n583jLFsWkKPYoWv31XCy3sTKvWzaVOx1tIro+wdwXqSIdflqRo82T/upp+idv3y5sa/6MWOMZYg0\nlfz3X0ozIyNgAueUcHvb2LnH6msyYkSgfXzySX/r1UsvUfwVK8S1gXbyoP9fcM69UwZyI7CAOC9o\nAXF1TZySqu+NAOyzmHZIYS5cMC78s8+KveBGoXZtOxffXVBGdMLRooV4uXXrGstLSREn59VXzcvH\nOefnz4stn9FC4qJFA3F++EH8qJ9e0OPrr72V8fHHwed37w5d7C4yKCMk6rU3foXDh6mTPHYs2dyK\nSvebbzifOZPzChXod506tGh540Yq64cf6v/vo4/o/P79YvKh2MU2buzP9dSiPqe3OZKoUbFw2E1L\nUQZatQofz2yE16trvHhxQMaxYzRa/sUXgd9eyj15khZpVqpEx3r1Ci7zuHHe3Murr/a2nvp9D7WD\nA1o6diRnDGlp9H6zkxezzmWzZmQzvnt3qFyRs6PKgnNlBnvJEuvXXYveBohO7rE2jrKRX8uWYsqs\nngHdsoUcFVjJh991W/+/4Jx7pAxwzgGgDYB4ALsBDMw+1g/Ak9nfnwWwFcBGAH8CaGwx3ZDC/PST\nsXlFv37e3oBwN0Pk4mG9oIxUc06dic6dOf/yS/OXmdNw/fWcN2pEpiZa1Dv1uQ2tWul7RVGzYQON\nOogsn9FOp37Vn3B1iXO6vyJl3Hdf8NSx9vy//3pbxmnTInd9c+UKfBc9XasXevak0SitwqW9524W\nD6uDMlvq1/VUo52x27AhtC6LuuZt2lBHVM0HH9CsjN20GjemWY6KFc3jvv228UyiV9d4yJCAjAkT\ngq+9qFkzvfDQQ9Tuq489+GBwmZXdmkXVIQXRAwUzZ4bKyMykejR2rPf3sHNn/XJq5SrlHjpUfB5e\neilUrtOZJb1w7bXB5j1Dh4Yvsx7Ll5MXtHbt3Nej774LjaMMOIoaNC1WLPQehru/XgSFLl3Iq591\n+eCce6gMeBX0lAEl6NmuKt4H/Aha+X7I9FOWEq67LricXik9igccLSJnIdTh2DF9eX5eW+195ZxM\naNq3926Ud/ZsMj/SHhc1amIUvvkmctfX76DMFIR7+XAuzkzI7qii26BG7YUHCJ3J1LquFC3frzJ3\n6hQsd9o0ZyOZVoO6U6X2JsK5O3e0ToK2Uyti1tKvtjctLZD+hAlk863Ng5fXLtwaRz/undZrVmqq\neHMsdRg2zLi8emi9WdkNp04Fv8v14iimyPfcI66cWnlz5waXa88eb+8r58Fu1tX89Re95/X/C865\nfn/b473evCMrK9SjgeKFxA/S02lHvmhH7V3iwgWxHpPUjB2rv2mKVzvtTptGnhBefpl+c07154kn\nyLuOn1y8CBQuTF4s+vYNbPDiBUaePKzsXuqGFSuAOnW8lZFT2LePPpctCx9P1E7GaWnZzXwEmDMn\n+LfWi8qjj3ojNy1N/E7Q4Zg9O/A9NRXo0cMfuWfP0g7QavwsN0Be4vbsoU3KAGeehLSkpgbvFK/e\nPVckPXsCM2eSR6LHHvNGRjgeecS5NxgRaL3gLVsGrFzpnzwzjh1zJ++66+gzXPu3dCn11QoVcicr\nHB07BuehTx/vZAHAwIG0K7SajAxqF2+/3VmaEXKY6B49l1YzZ/onX+ueyitXYpFGebizsoCrr/Ze\njhav3IC9+CLwyivA+fP0++WXgWLFaAdSvylShHYkLlbMW0UgkkyaBNx5Z6RzkbMQ1alr3Bi45hox\nabllyJBgl8he7Iqt7PDr5ctdD6Ut8sM1IWPkfrBYMeDDDwPHO3SwtguvaCpVAuLj6bsIZaBw4eDf\nblzshmPWLPo02lXaayX6xx/9V97UaPslXr7DAfvKgB+DGJs20TPrZmdxuyg7vHvFBx8A998ffKxa\nNepLOOWKVQa0W4P7PTIWCWWAMRpp8JOMDKBbN/JN7iVGLxivX7yKD/xPP6XPSHXGRW99nhPR228g\nVpkxA6hhe7cVffbuFZOOXYYPDz02axZ1HLOygO3bjX1puyF3buDcOfHpmqGMLPulDPz8M31X+1Of\nPx/46CPv5evxzDP0aWXPHTPUHeSFC2kwxCu6dgVWrTLPh1fkyUMDT5FA6ZekpwPjx9MstJfkRGXA\nL/r1o88dO/yX/dZbAt4DRvZDOSEAxmsGvvsu2E7Kzm6MIsI99wTLz53bX/nRFrSL1PyyvTt4MNj2\nTwYZZAgfNmwwt5f305mDn+H4cW8X8Cph+HBvFpS6Cbfdpr/eyGlYt068y2g7gXOxbjatyOOcFtxu\n3uyPTGUBsV91qVQpWpSvvFfDIdKrUb9+nDdo4P+91B6/eNG/PDgL4Eb9bSEzA4yxNoyxnYyxXYyx\n1w3ijGaM7c7ehdi19fDDD9MudAp+jzouXRr4PnlyZKcCo4GNG/WvodejcOvWBXa6lEgk5tSrB9Sv\nHz7O+PH+5MVvmjYlu1w/iNSu50YcOyZuNgsAGjYMfo9GAq2FgR80bgzceqs/srKygD/+8G/28Ngx\nWl8yalT4eCkpZAInivHjvVt3okdWlr6p+hXd7gkYvc+FwD4DV4H2GaimidMWwMLs740BrLGYtqmm\n060b+XktXtx/LctIO5TBedC6/PTa5aUMMsggg53gtectwFuPLzkpiN5PxU7gXKybTbPw77/+zCqp\nQ758kbm2yj4eJ0+SxzFlczKFGTMid99FhPz5I58HZwGezgw0ArCbc76fc54BYBqAjpo4HQFMzlY+\n/gZwDWOspADZ+Okn4O67gdOnRaRmD879lxntXHcd8MILpOW//nrkR44kEolEjdeetwBvPb7kJK66\nKnKyR40CSpTwT17t2kCZMv7JA/ybxdLyww/0OXIkeRxr2RLo359m4vv3B7Zti0y+ROGVl8NIIsK1\naBkA6mVih0AKQrg4h7OPHRcgP2JcvhzZxixaGT2agkQikUgkXvDii5HOQfRy+jSZ/SoDpqdOkRcs\nrz1hlSgBnDzprYxo5YrdZyAnkJ4ulQGJRCKRSJwgZ9ejlzx5zNcWiSYaR+z9QoSZ0GEA5VS/y2Yf\n08a50SSOAUwV4kxjv/qqtVRFULhw9O4vIPGehg0jnQNvWbuWFq9JJJIrjy1bvJfh1aZ0kpzB+vX+\nyrtwwV95OZ84BPehjRGhDKwDUIkxVp4xlhdADwDzNHHmAegNAIyx2wAkcc4tmghxVYgzjd2uncVc\nSyQ+8/TTwJgxwKVLtIHPbbdFOkfeUqcOcMcdkc5F7DFxIvDZZ5HOheRK55ZbgK+/9ldm6dL+ypNI\nops4BPehjXGtDHDOMwH0B7AYwDYA0zjnOxhj/RhjT2bHWQQgkTGWAGA8gGfcyjUiXz6vUpZI3FG8\nOC2eKliiBfUqAAAgAElEQVQQqFIl+meV8kgjxIjQty/w7LORzoUkGujb1195CQn+ypNIJIQQT8ac\n818451U555U55+9nHxvPOf9SFac/57wS57w253yDcWru8FIZqFuXRksk0UtcHO3m5wXazn/58t7I\nySlEm7LTrx/QvLn1+GPHAtOmeb/rp0TilmuvBV56KfS433sdRGowz2+lRyLJaeSwbU3ckzevd2l3\n6wa8/7536XvFjBnG27FLghk8GHjnHX9kRXr01k+3elc6RYoAX3wBVKpk/T/PPAN07w4UKuRdvsJh\nx93y++8DP/7oTM6NNwKvvebsv5KcQa5ctAYukqxcGZmN1mbNIteXEokT+vYF8uePdC7cE3XKQL58\nQJcu3qTNGHDffUDnzt6kr0flykDbtu7S6NLFvX26NL8K5sUX7dvDa0fK8+WjkWOrzNOuxHFJ2bL+\n7UwZLRQtah7n/vuBTz7xPi9m2Nnhs0oV4MEHncl58UXgvfeARlqH0pIrBsb0d4D3kyZNIiP38uWc\nt9uz5Mrh6quBFSsinQv3RN0joHSwBgwQn7bSYPz8s/i0jYiPBxYtcp9O7tzO/ztsGPDKK+7zEE10\n6ybGU0737sCECdbi3n+/e3lqMjK8nUlTKF48+HdCAvDtt8CHH3ovWxSKImdlHcS8eeLaHz/uD+Cu\nfbh0idpGv2bUJOLJlYs6xbFIrJY7mhk2zD9ZnAONG5NVwZVMVCoDefJ4MzKnKAPXXis+bSOUTsjE\niTRysnats3ScjnycOgUMGgQMGUK7BkbK5CEaMLKh92omy4yMDG/2yRgyhILC3r3Avn3A1q1UjytW\nBPr0IQXTz1k2NygzYxkZxnEef1z87M0rr9B1a9VKbLpa3CgDypqIaN5zZfNmYPt27wdFIuUNTzsz\nULNmZPIRCQoVip71Td26Ad98E+lcRJ5Bg/TXwHhJqVL+yhNNVCoDXqEsMtKOdPpB375kU+nG9Zqd\nDTnGjKERa6WsuXMDNWoAVas6lx9NONksx+iFU6CAu7w4xStl4H//o6Bw9dW0WLpmzeCFeowBtWqJ\nl6+wZo04W3alXUlPN47z1VfiZ29y5fKnY+ZGGVDWUUSjMjB5MvDTT1RPq1cHRozwVt6bb4Ye86N9\nyJUrWBlYutR7mUY8/ri/uwPfdx+te4kGpk8HeveOdC5yBn7uOQX4N4vrFa6UAcbYtYyxxYyxeMbY\nr4yxawzi7WOM/csY28gYczi2bQ2vlIF33w10jK++2hsZWr78MvRYmTLA/Pm0KNgu+fIBTz5pLW7/\n/sD//Z99GX5TowZ93nmn2HTdjtYPGhR6zEgZsNKJWrLEXX7UVKtGn6NGRWcHTqFxY+CDD8Skpdy7\ncDMDXqDI9XqnVqcvslq1Agqe33XJD89ujzwCdO3qvRwFPbv91avpGltV2OrVow5hlSrW5ebKFXg3\nTJvm/yin+jn96ivg00/Dx7ezkN9Mbu7c9P746Sdgzhwx6VrFi+ucKxdw/fXi073S8Mu1tdI2JyYG\nHy9QALj3Xn/yIAK3MwMDASzlnFcFsAzAGwbxsgA045zX5Zx7uszMj4WuU6d6LwMwVjrat3c+Qj98\nuPP8ADnPHWbbtkBWFvDLL6Hn7rrLXlpvqGqvmbJ1ww3hz+u9uG+9VT+ulSnqpk3N41jlllvomrVv\nH3llICvLm3R//VVsegcP0qdTZWDiRGedV6VueHWdFJzWg4cfDrx0/axLjzzivi3LadSooa8M1KtH\n9cfqDMHttwOTJtkbtHrwQRokyMqidUx+Y+e9feIEsGuXGLlqs9euXc3bdT0qVLDuiemHH+hz0iS6\n1n362JdnhWPH9Gd3li0j99lekxO867iZ7VQzfnz4dX2KMqA4YFAcvjz8sDiTrW++AerXF5OWEW6V\ngY4AJmV/nwTgAYN4TIAsS6ht40Xazqk7bOXK+fNAheskGmm9Zi8Ms7UDI0bQomUjJk4EBg4E7r47\nfDqiePJJGhU3msZljELhwqEPyzXXWM8nYzT7Y4U33wRuvjl8HHVD9O231DB37GgtfT1EjnKkpwfq\nlsgO3J49wO7d9v7j1eiN6BGZcuXo8803qdNm1y95377Ali325bqdGbC6dsppPVDXcydpJCSQPb4T\n/J6lUfCio/Pdd+SYQtvm//VX4LvVdV9KGnYWxirmT17Yzt93n7lnKzty8+Wj+AcOuMsXENr+OCl/\nQgJw9qy1uN27k7lu794kyyvTEsbIE6GW6tX9WeiamBhcdyOBqHdLkybWrCRq1aJnbsEC4LffgM8/\nt94mmim3jz5K7uF//91aenpsMNndy20H/XrO+XEA4JwfA2A0OcUBLGGMrWOMPeFSpmUefRTYuVNM\nWtrRkhdeANq0CT72ySfAxo3uZfXpQ9OH4RYNGo0UmjWQZtryK6+En14uWpTcCHq9kHj0aKBBAxr9\nu+eegLxwC061Lz/GrI+oTpliPW89e5rHYYy8Df3f/wG9epEf63AvGrP7IvIlre5E5colbqHVzTfb\nn75//nkxstV8/33wbxHXTlnbcNNNtJBebZb22GNkyuEFSt47daJPu2uGBgwgZdQMpVNi9/6pO6h2\nRuI++YSU74oV7a0bUTqVbdoEZkf9ttX94w/qzD30kLg0H3qIFM677waee47ajMmTg11CW63HdpWB\nm28Of++sejszol49YPlyuma//65v065XtvHj9c38lPstws5fhEvR3LmtdzwZC54FMXqeRYxqq5+L\nnj3p2VHMkn7/HXj5ZXHPzpQpdI8B6reUKkV1d9ky66bJohGlDCh9DyuWBrlzU51q0YK+W1UGKlcG\n/vkn/H5QBQvat3ZQU7euSQTOedgAYAmAzaqwJfuzA4AzmrinDdK4IfuzBIBNAO4yk5sdn9OYmHmo\nUoXzChW4LlbTMArDhumnm5YWHI9zzjMz6XuTJs7lrVmjL0/Nv/+G/m/GDP3yqjl/Prxsq8yZQ/HL\nlHF/fZXQqRPnX35JZdOyeTPn7dtzfuoU53//HfjPq68G4vTvH5xe+/ac//ijNdl6PPxwaLyffgqO\nY5Terl3WryXnnB87xvnx4+b5c3N9a9emz6FDg2X/8ouY++eUL78UV4caNAhNPz6e89GjQ+Nef731\ndPv1M86zHeyWZ9Ys+l9mJufbttEz7uQ+mP1n82aKl5TE+YEDgePz55Nco/+NGhWQkZnJ+aOP0jNp\nN49Wr8cnn3C+dSvnWVn0v61bOf/tN+P4+/YFnqsqVcTW6aQkzj/8kPO77vLn2Sla1Fpazz1H8atW\ntRa/YkVz2W7K9vbb5umNGWNddmamu3wtXBj4/tVXwbKSkpzfuw8+CK1nhw9zfuQI1ZMXXwwt2+XL\n9Az17h16T8I9d1bq0Zkz5vWrYEH3dbdAgUB6W7dynpxsfg+9Dpxznp4uJq1Tpyi95OTge1KuHH3+\n8Yfx9b1wwf59c3LeLLRvr/wXnHOD/rbRCSsBwA4AJbO/lwKww8J/BgN4yWL6PDgMDnsxlReE6Io4\nfLjxzU5MDL1hqamUF6fyrCgD6emcN2rE+eOPh8o/edK4Il26ZL1SmpGSQg2c03IOGkSfxYoFrplV\n8uen/6qVgZQU/QcgNZXzHj3sl1vvHu7cGRxHe75VK84zMuxdx3DpafP3+uvOr/fatdTxT08Plhlp\nZUB735yGtLTgjoLZtR09mvPWrUOPlygReuzCheC0Pv/cWbmtlmXwYOrkap+JrCzOf/2Vztu5D2by\nNmzQj79sGf2eO1e/M63XiVu/3n5dsXpdxo0L/e/u3cFx1PlUSE0lpdDKdbBbp9u18+fZKVbMWlrP\nP0/xK1Y0jvPMM4HvlSuby2bMedkGDw5NTxtn3jxj2eGulZP8nDsXUJR+/TVUXkoK50WKOLt3Shtk\n575yzvnLL4fWYc5JUXBajy5eNM9HoUL2r1+1apwvXcr5Cy/Q78KFzcvn9vlw8jyp74OdcMMNwb9T\nUvTLMmIEtSvhSE21f9+05+bPd3MtB3NtP5pz/f6220myeQAezf7eB8BcbQTGWEHGWOHs74UA3Atg\nq3UR6nLEhZwdNChg4iHa3lFZtBluQVWFCsDs2cG20opNo5dcdRXw99/Bi14VrrsusAD26aeDz4Wb\nfrRr0+7UdrZsWWDoUNoY5McfgU2b7F8zzulT/Z/8+YPXDSjn8uULNemygpN72KSJt14M3n/f/n9m\nzyaXcw0bAq1bO7PtvuMOY/OoKlXc2ejnzw+8/bbz/yvkzWtt2n/IEFrA99RT9KyoOXCAFiiqTVem\nTAldIOjHgt4WLULrIGN0ra0uWFRISNC3IVZISdE/rsjv0EF/LZFeXRJZ//v0AUqUCHjn6tAhNE6l\nStTe7d0LHD9O9rpa8uWzZnpRty7w8ce0GHD7dmt59GtvgHHjrMUzMxO6++7gtSRWnpmEBGuyw+VH\njxdfpOerfXvjOJs2Wdtfx8pi3Ndfp4XVy5fTOg09U9z8+Z27VrXaBmnR1k3FfMeNGY+VRdlOHK4U\nKkRmrwo5affm4sUDXhid5GvrVmD9ejI17dOH0jO6RrlymV+/fPmAhQuBdeuM45itmapePfz58MRh\n376gAXZjjLQEKwFAMQBLAcQDWAygaPbxGwAsyP5+E8g0aCPIxGigjfRtaVRGmKUxcybnY8eGHv/u\nO3uj1XblGoW//rIuQz0LoEUv7+Gmzpzw/PP2yyeCfPkorddfDz5et25ATocOgeNZWQEzGW0YP95Y\njjbu9u3B55cvp9kA5byRSZlVKlUKlak1fbF7vbdsCS/TysxAONlunhGFt96yXp6OHTmfPp3zJ57g\n/NNPrdcrJd7IkYFjBw9yXqoUjbru2RM4roycfvKJflojRzqrz0ZlevFFzu+5J/D7nXfCp7NjB8V7\n8EF7z5eRfO1skXJ85Ur94+3acX7vvaEzJpxbM28wy9e119LnwYOB+mW1nh07pi9HPYurF9QmT3bI\nyiIzq1697D+bdutQVhbV/XBpKeYopUvrn2/WjM537Uq/q1e3Jttp2bRmieq03n/fetn1rpVyTDHf\nNMuLlVl3zjlft87dvbN7X994I/CfkiUDbfa4ce7q0XPPkUmjEWvXct6yJee5clmXcccd9N9+/eh3\niRLm5XNSbwYODH63moVChULlvvAC5zfdZO3/zZrpz8QaleXTT83LrU7nqac4nzTJ/J5pz+/bp3++\nVi36rFHDep2gLr9+f9vVGA7n/AyAe3SOHwXQPvt7IoA6buQoVKxIHktuvDHg6k8EzZrR4ppnnw0+\nnitXzt+Z8JrsnR30Fv3q5f2qq8hzxJ9/0iK1bt3ouNONbex49HjrLXGjaJybH1eXnzGgdm3g33/J\nfdzRo4Fz4RY4VahAu+cayW3WjIKoerJzJ7kXVI84ON11+uWXqbzKvgJOmDvX3CWmiLIb3U89FF/g\n3bqRF48BA6z9b+ZM2oimV6/AsbJlg+uCwkcf0Wil0YyHMpInagFe06bkW92q96Bq1cgr1Nq1NOuj\nPm4FpQ09e5YWphnNFmlH+R9/HPj6a5rZM3J1J2JmYOVKKl/ZsoFjVuuZ0YhguJmBvHmdL2ZXNs/z\n413BGNX79HSaFf7449A4Svm/+45ml4zOK3u0NGzoLk+lSwNHjoTPs5NzVpg5k2aDrO4FEWlXykYo\n9yRXLnILqmDHI5Qeo0eHP9+wIc2C3HADyW3XjvoS27YZ723zyCP02aYNMH58Jnr23CPM1auaqlXJ\nC5uRy10tnId65XnmGQpaV+xFiwJJSTQz1bAhsGMHlcuON7xTp+y5uNW+p4YPp3bHLI0DB4C0tMDv\nhx6imYv33qM+8auvGs1iVsT48dZXovu0LYM7HnuMpvZLlyaTh9tuo5e14s/VjHnzaEMRrceYBQuo\n02Xk9szt9NeqVTQlWcdAFfr0U2pEtbta2jG/ueoqMmsoUsT6f155JfTYqVPW/++Ud94Rl9Ytt5Cr\nLK1f6HDmG0oHK18+YOxYUv7MPJns3AmcPx/YxMWsk+b25ZY7d2inxWmaTz1lzTtMwYKhxwYMINMg\nPbMML7CjDKix0/Hs3Dm8Nyo1BQqEb1/69iXXeV5teW/lelx1VbAv+RMnrPuWX7yY6nTRovrnq1Wj\nuq91oTt+fKAtNkKEMlC+vPPNHUuUIG9vTZoEHw/3HFl1DRkOPweOlEGdAQPIVeSECWTW8MMPAdPQ\n5s1JyVy5Mvi/ynvtjTdosMPtBovz5tFmmLVq6b9HvFQGrD7PClbrptP2yCllytCn1uPLNbrbuIpH\nKW+ZMtQvUXzmaylfHujXj74/8ACwatUeJCcnggxAjAnnrtwMq+Z6buQ3aCAuLbf/Nzv/v/9RUPj4\n49BBgcTERLRpAzz5pI2dB42mDHJCAMA//DB0AYdTrE6/KOHHH72Rq4QTJ4LPz5wZ3mTFC/bsoWl1\npxw+zHnz5px3724+DSeSQ4c4f+89WrClRr1ornPn4HOKacdjj9H/3nuPPKdYQUlT8bpidP7dd+2X\nRY/p0zlv3Fh/gZvVaVOrHo2ysmg6Wr1w1oi8eb25r6dOBRaF261H33/P+caNYvLhNUZlmjMn+PyI\nEdbTHD3auF4ayU9MDB/v3DnyDOKEffuMy5mQQN59tJw8SfVViSeqzVejXWgsug7reR+zEnr3dic3\nLY3zf/7RP6fn1e7ee53JMcq/Uk8OHqQF5drzeg44lHMffWRd/vz5nK9aFT6OnrmvOpiZTCqoPdY5\nea9NnRpYfG+FjAx65hXPNQrp6ZzXr+8uL1ZQFkwrJmaKCZkSihen9+WRI8H/i4+P5/Hx8c4FSzwh\nPj6eA6H3hbr8HngT8jpAcA+ySxcq8auvcl6vHrn1UqNU/F69yE1pUpIYuUYPrvLg222ociIffuhd\nQ2WHlStJ1lVXBduAc04N7oIF+q7PzPj4Y7Kt1SofCkoZRSkD4TC7zg0acH7LLaF24GZs3Wp+r9LS\n6Dp260bxtGs23DJsWM6oR16hLcsjj5BN6/nzdH7mTPqt12EWwYcfUufCjccrM8LZ5puhxAvnFcop\nGRmc16mjb9svgkcesd5pU8KlS2LW3Bixdm2ozC5dnKVlVAbtoIP2/HvvhaZ16610TuuqWQThrve2\nbdbSWLPG/N5t307KrdeYrRERUY9/+YVcZSoDpEpfSQlly+r/TyoDORMnykAOWgfuPd99R1PpH35I\nK8aNbEj79qUd9LyeolPk//wz2XfXrOmtvEiieGbymiZNqPlKTw81cciTh3bDdLI+4qWXaLrSzEY8\nJ6wxmTuXdru1ax9rZf1H3rx0HadPp+vsxLtROIzujWLK4NfO116hXdvz+OPkBUcx8+vcmX5fb7R9\no0tefZU2t/HS41X58mS+8tNPgWO//EJyreKFh5I8eWhTyNdfF582EFhzZufeFSzobZvRsGGoCcTI\nkWLSVtp0s82/9Mr366+0m71dMx+3WK1XNBYZnurVyWY7GmjdGti/n55dwHtvaZKcR0wpA/nzkz2p\nGaJ31736an2bfqVhatOG1kDkhI6kU8Llff16cq8VC/hxD7VKjhanu1cqa2ec2mp7RVYWuY7csIEU\n5yuZtWtpUXc0wxi5rlQ7C2jd2njBsZoTJ9zb5JohYndXPRo3prr66af0W1H8KlTwRp5V1Isv69cP\nXpTthq++ovKarXHTaxNLlaJBNy+UvhMnjM9ZXVtnRRmIZrQul68EDh8+jAceeABVqlRB5cqVMWDA\nAGRkZGDSpEl47rnnIp09zJ07Fzt37vzv9+DBg7Fs2TLP5Nkd8HH1KDLGujLGtjLGMhlj9cLEa8MY\n28kY28UY82hcxj2jRlEDbrpts01OntRfWJWT/PO6Ra/BHzCAFIF69cQrWDkVUd5lwmHWWXLiOxoA\nypUjH+2q9sp39F7CSt2qW/fKr0fXXAPcemukc+EPyrNgp/NZooS+ZzSReKUMAFRXe/QA5s8nn+UX\nLgQv9osE6lFep17j9MiTR7/d1+7L4/cgl9GA33PPBRbqmnFT9npYKw4YopF336WZLmUfhithoLJz\n587o3Lkzdu3ahV27duHixYsYlL1BCRNcgEwr7o00zJkzB9u2bfvv95AhQ9BCz92XIGbOtBffbXd0\nC4BOAFYaRWCM5QLwGYDWAGoC6MkYc+Hs0Duef546Wk430zIib179TmK0KwOffEKKQCzhh+s6M43f\nzQu/RYtQD01+YmXmTnJlkCcPuW31wu2gG7xUBgBq19u3p7agcOHIt/NqBVvE5n4KRm3d99+TyYlC\npMuv8O671uOWKgUcOkSbk0UarVcsI159VZzM664DPvtM3CyS1yxbtgwFChRA7969AVDn/5NPPsHE\niRORkpKCAwcOoHnz5qhatSqGDh0KAEhOTkb79u1Rt25d3Hrrrfgp265xw4YNaNasGRo2bIi2bdvi\n+PHjAIDmzZtjwIABaNSoEYYPH44Kqim/5ORklCtXDpmZmfj666/RqFEj1K1bF926dUNqair++usv\nzJs3D6+99hrq1auHxMRE9O3bF7NmzQIA/Pbbb6hXrx5q166Nxx9/HBnZNrs33XQT4uLiUL9+fdSu\nXRu7shvTVatWoW7duqhXrx7q16+PS5cuhVwTuy7F3e4zEA8ALLza1QjAbs75/uy40wB0BBDB8cec\ngdcvJT+5EkYOvGTxYvIbnN0Wec6RI6HuHWvVorUCfsxOeEWvXuT//sCBwE6SkiuXUqUinYNQ/G53\nu3YFvv2W7MsnTPBXNhBoD1q3drdTuBYjZSB3bppl7NaN1o2E2/naT+zOKpYpE97kyC9KlqT1XM2b\nA6tX68fJzPRG6bJrLnXXXaREiaRsWeNyK2zbtg31NXaIRYoUQfny5ZGRkYF169Zh27ZtyJ8/Pxo2\nbIj27dtj3759KFOmDBYsWAAAuHDhAi5fvoznnnsO8+bNQ/HixTF9+nS8+eabmJD94GZkZGBt9sY/\nGzduxMqVK9G0aVMsWLAAbdq0Qe7cudGlSxc8/vjjAIC3334bEyZMwLPPPosOHTrg/vvvR2fNQpm0\ntDT07dsXy5cvR8WKFdGnTx98/vnneD5745Prr78e69evx+eff46PPvoIX375JT766COMGzcOt99+\nO5KTk5FfwAi2Hzp7GQDqLcIOZR+LeXLKiInEPa1aAStW+Gdvrx6937uX9rTYuBG4dOnKVszy5AEG\nDSLTiuLFgWnTIp0jSbThtzJQqBCNMKvXUJQtG1hb4DWjR9Oi5uHD3aWzZw/w+++B32Zt3bhxZKrQ\nvr07uSKYOtVZu6iUsXx52t/o6aeBP/6wtzmVCPLkCb+niVd9iWuvpU+9vWiuBDjnYIyhVatWKFq0\nKPLnz4/OnTtj9erVqFWrFpYsWYI33ngDq1evRpEiRRAfH4+tW7eiVatWqFu3LoYPH44jqh31uqts\n4B588EH8+OOPAIBp06b9d27z5s1o0qQJbr31VkydOjXINEiP+Ph43HzzzaiYvRq9T58+WLVq1X/n\nO3XqBACoX78+9mXvgHrnnXdiwIABGDNmDM6ePYtcAiqA6cwAY2wJgJLqQwA4gEGc8/muc2Au/7/v\ngwcPRlxcnNcifSOn7oboBOl9wH+aNQM2byb7VsXG9UpttLWUKePPRniRRqQNt8QaOWFG9uBB8zii\nuP122qXXLTffTGHzZtqt1qzuXned/96CFGbNCpZ9++3O0smfHzh8mDrFkX5W3e5G7IQhQ6juZJve\nm2I2gu8VNWrUwIwZM4KOnT9/HgcOHEAeHbtaxhgqV66MDRs2YNGiRXj77bfRsmVLPPDAA7jlllvw\nxx9/6MoppJpe6tChAwYNGoSzZ89i/fr1/9n/9+3bF/PmzcMtt9yCSZMmYaV21z8deJgpmHzZiwBz\n586Ny9mV4PXXX0f79u2xcOFC3HnnnVi8eDGq6Cy2iouLw5AhQ0zlAxZmBjjnrTjnt6pCrexPq4rA\nYQDlVL/LZh+zhNoP6pWuCAwbRrspL1oUuhvylU6se1+IBMuW0eJ0yZXHt9+SFzHRzgok5kSqrYqW\nAZNatQILS3MqnToBVasGfrtx1Vu6dOQVAUDf/LNVK5r18IoiRWgNSI0a3skQQcuWLZGSkoLvvvsO\nAC3wfeWVV9C3b18UKFAAS5cuRVJSElJSUjBnzhzceeedOHr0KAoUKIBevXrhlVdewYYNG1C1alWc\nPHkSa9asAQBcvnwZ2w22QC5UqBAaNGiAF154Affff/9/A9cXL15EqVKlkJGRge+///6/+EWKFMH5\n8+dD0qlatSr279+PvXv3AgCmTJmCZs2ahS3v3r17UbNmTbz22mto2LBhkJciNXFxcUF96HCInFwy\nmoRbB6ASY6w8YywvgB4A5gmUe8UwaBDw9ddA27bAww9HOjdiiZYX3ZUEY9LU7EqlTx9yk+qlv3+J\nPjfeCAwdCixZ4q9cxeQkkgv0YwnFm9P589ExY3rffeQR6YUXAscWLwZ69oxcnnISs2fPxvTp01Gl\nShVUq1YNBQsWxLvZq8YbNWqEzp07o06dOujWrRvq1auHLVu2/LfQd+jQoXjrrbdw1VVXYcaMGXj9\n9ddRp04d1K1bF3/99RcAfY9E3bt3x/fff48ePXr8d+ydd95Bo0aNcPfdd6N69er/He/RowdGjBiB\n+vXrIzEx8b/08uXLh2+++QZdu3ZF7dq1kTt3bvTr189QJgCMHDkStWrVQp06dZA3b160bdvW9fVj\nZtpC2D8z9gCAMQCuA5AEYBPnvC1j7AYAX3HO22fHawNgFEj5mMA5t7RVEWOMu8mfxD8++AAYODDw\nu1MnmqqVSCSSnMqMGbTAtXZt72VxTr7527Y136hLIjHi0CGqP3FxwODBkc2L4t1Gz0RFEjmM7gtj\nDJxzXQ3DlTLgNVIZuHI4c4YWig0dSqMwdevmjKlViUQikUiiiczMnLH2RSoDORMnyoCcpJYIoVgx\n4M8/I50LiUQikUiim5ygCEiiC2lxLJFIJBKJRCKRxChSGZBIJBKJRCKRSGIUaSYkkUgkEolEIrFN\nYkHYoCcAACAASURBVGJipLMg0ZCYmIiblM2HLOLWm1BXAHEAqgNoyDnfYBBvH4BzALIAZHDOG1lM\nXy4glkgkEolEIslhZGZmYs+ePZHOhkSHihUrIrdmcUm4BcRBGxLYDQCqAqgMYBmAemHi7QVwrYP0\neawxePDgSGfBU6K9fHrEWpljrbwKsVTuWCqrGlnu6CeWyqomlsodS2VVk92n1u1vC3EtyhhbDuBl\nbjwzkAigAef8tM10uYj8XUlka26RzoZnRHv59Ii1MsdaeRViqdyxVFY1stzRTyyVVU0slTuWyqom\n3MyAXwuIOYAljLF1jLEnfJIpkUgkEolEIpFIwmC6gJgxtgRASfUhUOd+EOd8vkU5d3LOjzLGSoCU\ngh2c89X2syuRSCQSiUQikUhEYaoMcM5buRXCOT+a/XmSMTYbQCMAlpQBxvTXOkQz0V7maC+fHrFW\n5lgrr0IslTuWyqpGljv6iaWyqomlcsdSWa0g0rWo7pVljBUEkItzfpExVgjAvQCGWEnQyLZJIpFI\nJBKJRCKRuMfVmgHG2AOMsYMAbgOwgDH2c/bxGxhjC7KjlQSwmjG2EcAaAPM554vdyJVIJBKJRCKR\nSCTuEeJNSCKRSCQSiUQikVx5+OVNSCKRSCQSiUQikeQwpDIgkUgkEolEIpHEKFIZkEgkEolEIpFI\nYhSpDEgkEolEIpFIJDGKVAYkEolEIpFIJJIYRSoDEolEIpFIJBJJjCKVAYlEIpFIJBKJJEaRyoBE\nIpFIJBKJRBKjCFEGGGMTGGPHGWObDc43ZYwlMcY2ZIe3RMiVSCQSiUQikUgkzskjKJ1vAIwBMDlM\nnFWc8w6C5EkkEolEIpFIJBKXCJkZ4JyvBnDWJBoTIUsikUgkEolEIpGIwc81A7czxjYxxhYyxmr4\nKFcikUgkEolEIpHoIMpMyIz1AMpxzpMZY20BzAFQxexPjDHuec4kEolEIpFIJJIoh3Oua6XjizLA\nOb+o+v4zY2wcY6wY5/yMhf96m7kcBmMsqssc7eXTI9bKHGvlVYilcsdSWdXIckc/sVRWNbFU7lgq\nqxrGjK31RZoJMRisC2CMlVR9bwSAWVEEJBKJRCKRSCQSiXcImRlgjE0F0AxAccbYAQCDAeQFwDnn\nXwLoyhh7GkAGgBQA3UXIlUgkEolEIpFIJM4RogxwznuZnB8LYKwIWdHO4MGDI50FT4n28ukRa2WO\ntfIqxFK5Y6msamS5o59YKquaWCp3LJXVKiwn200xxnhOzp9EIpFIJBKJRJLTyV4roWvO76drUYlE\nIpFIJBKJRJKDkMqARCKRSCQSiUQSo0hlQCKRSCQSiUQiiVGEKAOMsQmMseOMsc1h4oxmjO3O3oW4\njgi5EolEIpFIJBKJxDmiZga+AdDa6GT2rsMVOeeVAfQD8IUguRKJRCKRSCQSicQhQpQBzvlqAGfD\nROkIYHJ23L8BXKPeiEwikUgkEolEIpH4j19rBsoAOKj6fTj7mEQikUgkEolEIokQcgGxRCKRSCQS\niUQSo/ilDBwGcKPqd9nsY6Ywxv4LcXFxXuRNIpFIJBKJRCKJGuLi4oL60OEQtgMxY6wCgPmc81o6\n59oBeJZzfh9j7DYAIznnt1lIU+5ALJFIJBKJRCKRuMDzHYgZY1MB/AmgCmPsAGOsL2OsH2PsSQDg\nnC8CkMgYSwAwHsAzIuReqaSmAj//DJw7F+mceMP+/cDGjcDBg8Aff0Q6N96QlARkZAB//w0cPw7E\nxwMnT0Y6V95w6BDwzTfAhQvA0aOA1M8lEolEIokehM0MeIFXMwOcA3/+Cdx8M3DDDcKTNyQlhTrH\n584BW7YAZcsC995LebjqKvHy0tKAxESgShXg/HmgaFHxMvTQWnO9+KJ/sv3g4kXgo4/0z0WTJdvl\ny1RvJkwALl0KHG/bFmjcOHL5kkiuNNLT6Rm69tpI50TihhMngNWrgaZNgX//Be64A8ifP9K5kkis\nEW5mII/fmYk0ycnUGV+yhH4XKwbUrAm0bOmt3AsXaBR59erAsUOHgIkTgerVge7dxclKT6dG6/ff\nacS6QAFSRB55hBQgE9MxxyQlAXPmhB7/91+gSRPv5J44AeTJQyP0ly8DtUIM1cRy/rzxudRUykue\nKHiyFi0CNmwIPb5nD9CwIZArytwPzJ9PHbbKlYFjx4B77qFnqUiRSOfMOzIzgWnTgHr1gIoVaVDC\nq+dUD86BM2eoHfZS7o4dwNy5QL9+QMGCQL583slSk5VFbdK4cdQ+DhzoT+dxzRq6t3fe6b0sANi2\nDShTBjh1Cti5E7jlFqBCBX9k+8n331P/YXP29qqpqUC7dpHNkxf8/jsNJlaqRDPgN99M9div58Zv\nOKf259gxaovy5o10jvwnpmYGkpKAkSOB4sWB06eDz3XpApQsCVx/vTBx/7F+PXU0wiFyRHnKFOqw\nabn6aurI9u0LlC8vTp6CWRneeENsY5KeTg/w8OHBx//3P/oU3VnlnJTIP/8MH69gQeC118TK9hvO\ngSFD9M/lzUvXvksX7xUvP9i5E8idm170agoWpMGDwYPpekST8pOeDkydCtx4I734FW66CejTx798\nbN4MzJoFNGpEJmj33CO2bTpyhEwW162j30WK0MBMt27UFjZo4M2srMIXX1AHQ+Guu2gQ6OGHxQ4Y\nKK/JNWvo3i5fTr8HD6ZPLxWtU6eAzz4LPX7rrUDnzt7ITEmhQS6/yMigPsM331AnWaFqVaq75ctH\nxwBQcjK1c++/H3z8mmtICYqmmW+F8+eBTz6h2e6//yZLjd69qa8STW0+cIXPDBw4QA9f5crO08jK\nolHOggXpt1YRAICZM+nTi8q+ZYv4NMOhpwgAgRHttWu9UQbMeO894K23xDWa776r/7AOHUqjbwMH\nipGjkJhorggA1KCKJisL2LqVRmp27gT27gVatKBRDNGsWwcsXGh8Pj2dPleujA5lYNo0/ePKffzh\nB2DXLrF11wobN5ICX6AA1fNSpdynyTnVnwsXgH37KKhJTHQvwwpJScBvv1E+AGqTAGDSpIAyL4Kv\nvgpe46LI++kn+kxJoefIK9SKABCYGU5IoJH7mjXFyBk9GihcmNZpqZk0iZSsN94QI0dLVhYNPumx\neTPV3bZtxcrcuxeYPJlmJzduBO67j56PSpWAQoXEylKYO5faXy3x8RRuuw1o08Yb2X7y4Yf6x5X1\njZcuUfBi0DQSHDtGyjlAigBAz8sHH9BM1xNPRC5vfpPjlYGJE+nTTSc9Ph745x9rcU+fpo6kyEbF\nyqjM9OnUuN10k3M5mZn0kjUjI4MaturVaUTULWfPBqZNzdi1C6hRw71Mhaws/eOpqXRNH3xQnCyl\nExwJ/viDOk9qtm4FSpcGunaleluunJiZl3CKgBrOSdGtXt3bTvKePRQaNAh8Av6Zs+zaRZ+XLtEI\nmR/yrr2WOiBq4uIC09lO2bcP+PHH8HF++olMhurVcy7HjF9+IaVES1YW5a9JEzHrucwmls+ccS/D\nCYoCWqKEmI7V2bMUtCjKXmYmXVuRsyCpqaEjyFr+/hto1kzsKH58PH0qsz3Kc1K6NPDkk+LkqNFT\nBNTs20fXwwsTsKysQNqRHqn+6CN6pgYN8nZGzQ8OHKD+pdE1PWzJ+b1YsrIid49zvDLglpQU6vxa\nZcwY+hQxQ7B7N03FW7F02r6dghu5s2aR7aYZu3ZRaNkSuPtu5/IURo2yHnf6dODVV90pW3/8YW1E\nfPt2stV9RoDvqsuXaXbJKjt2kKJVpYo7uadPB+qkHkeO0KggQB24Rx5xJ88Op0/TjFrt2kCnTuLS\nzcwMLH7fvz8waqzMyiQkUIfguedoZKdGDWcd5F9+IZNBq8TH0wuiY0dvTNCmTCE762XL9ON8/z2N\nbD/1lLP0d+yw5sFs2zYKdeuKV7gyM6ljlZpqHGfHDmqf3n7buZx9+ygdM5KSqN1s2VKsordoUaDe\nhuPCBXfKQGamtbo4ciTJEjnzvXu3tXgffCBGblISeeHTm9kHqC3cvJnMk0SRnBxqPqjHsWOkGN1/\nP1C/vjj5ly7RO0xx4HDPPfRM3nknvZP8Nk1S+jJpaf4qA24HQdRkZpLp9qlT9NtoQBEAFi+mGVmR\ndcoIZcarTRtqI++5h65zhQruBvkSE2ngxWzmSkhVYoy1ATAS5Kp0Auf8A835pgDmAtibfWgW53yY\nCNnhOHQI+PprmmqPBAsX+uuG0YoioEY7pewXU6bQCI7TDpWy+NsKJ06QPWv//s5kKezaFX7hsBZl\n9NXtS9CoY6jHnj1kK1yjBq1/sUtycqhZgxX27jWPYxXOgbFjw4/YKiODipLUqxeZCNitT2vW2Iuv\nKIMNGpCtvSguXqS8790b/lpa7XzpsWULdXrt8O67pGD26OFcrpaFC/UXpWvJzKTnvHZtZ53lqVOt\nzeQdOkQhOZns+EVhRREAqJxueOcd8kpnhmIeJYqsLGDpUuvxt26lRcVuWL068OwbMWsWzUb07Elm\nU2757jtSMqyyZo04ZWDJklDX3Mo137iROrOvvCKmnH/+ac/T1alT1FZ50UnmnGZ7KlQgL4QFC9Lz\nXKYMKUF58rhToNevtz6wpwxAeakMHDkS3Db/8gt9fvstfVarRkpmwYLOFKJJk+jTzKTXtTLAGMsF\n4DMALQEcAbCOMTaXc66dBF7FOe/gVM7ixaThPPmk9Qui2M7b6cSpcauNOjHBOXOGRqjs/PfiRbJz\ns8uuXaQxVqrkfITh4kX7/zl2jDontWs7k2mXU6doD4C0NGsvTi3p6TSj4SeXL9ML9MABe/9buZLC\nU0/RqLed0ZsJE4xH3cKhmGQ1aeLerv377+2bbvz6K70snniCXhheE24kyS7JycZuao04eJBGSe2s\n11BGweyQkaFvyuMGO/X5jz+oc+VkhsCuSZ96Uahb7AwAbdhACtJTT9k3pVHkKDbPVhBlhrBrl719\ncmbMcK4MXLhAHWM9Myg9Dh+m9kCEyZAdRQBwr9wBwKZNNAMSrk4qz/OaNfSuuPded/d18WJ78ZWO\naunSwHXXOZerJiuLnBns2kX3cNOm4PNJSYEBTzeDbFZMqbUkJtKgsp2ZZDM4p/u4YEH49nnnTgr1\n65NS4JSUlPDnRcwMNAKwm3O+HwAYY9MAdASgfY24muRRNDQ7HXQ3Hfnhw8kG26nZxaVLzjpWo0eT\nJmhnNO7LL50rPNOmka/ke+919n+7HRkFs4pphNOZlrFj6dNJI2I2GuUFq1cDK1Y4//8XX9DIyqOP\nWv+Pk/oKUKdx+3Yy6Xn1VWdpHDhAo3BO1mUo+f73X6ofpUubvxjdzNgdP06Nc6tW7jtWdjsbAClt\ngDVlIDmZ1ppcvmxfjkj27Qt0IOxgt3O1d68zhw3Hj5O5Y7duVH+ccuiQ+ZoMNYqytXMnmWXZwUkd\nHjkSaN7cviw1aWnGi+69YMkS62vSFI4coVnSOnWc7+3gZCbuwgV6H7du7dxJh557biOUBen585Ny\ndt999gf23LSFIpTotDQqsxWzPoWpU6lte/xx6/+5cIFG3Z0obMroukgzu5Ur7b3j16+3pwycPRvc\nLzS7zyIsX8sAUBucHMo+puV2xtgmxthCxpjjJaRWRuWOHaObpiz8c0JGhrFXHjP27gVGjHAu2+5o\nnFNFQMHpdVqwwLnMX36xt5ZDkef3jsapqQFPU05ISKCOsl2OH3cuU2HfPuCvv5yZ/jhBvTGZHbKy\naCGX2wXaa9eSWaDiFcJI1hdfALNnO5ezaBFdVzsvL718fP01KUBOSU01v+bLltFL5N9/ncuZNs3e\nehk9Zsxw/t9Ll6zPxkyeTCYUdklPp5fnzz/b/6+ar78Wb5Kjh7Ig2C7nz5MJhhvl0Gm9V5R1uzht\nF1auDDggcYKVtQJaMjJIEZk61ZlMpzMLK1ZQvTdb6CyarCzrMzZ6pKaSl0G7dWrXLlK8V6ywPqux\nZAnNLIie7bTLqVPAsGHOBvt++sm6kvr55+QK1yp+rVteD6Ac57wOyKTIhu4bTFaWeYOidAbsTJ+K\nxMjVWk7l1Clnio9VD01GDB9urwP5zz/27FT1+P13YN486/Gt2DeH47vv7JkYpaVROUWN5P76K3V+\nzTDbB8Mq06fbMwU5fZpcwYpk9266hnqLVDMySDmyO9KoR0aGs85NZiaV2W37NGYMDTqEy0O4hbpW\n2bnTug28HocPOzMnVBgxgty7+oGb587pbKcT3nmHRqCdYtVjmB5OO3+zZ1MHxQ6Zme5m+C9coNFz\nu7Oeq1Y5lwk4U9T++ovuqxs2b6bOtVVTy9On7b0PtUyfTjNqJ07Y/29GRsD5hVNWrCCrkTNnzL3/\n2B181GPTJneDzElJtIbRaTuzbZt1JVWrRJvdIxHKwGEA5VS/y2Yf+w/O+UXOeXL2958BXMUYs+Qh\nfcgQ9l9YsSIOixYBH39s/LBlZopdYT9+vP0pURE2mVY6yQkJ9m39jJgyxfnIrhv8Hun/7Tfq4Fsd\ngXE762KXX3+lGRA3i0X1mDPHeHT49GkaPRbB9u32RuPCeUpyyt69dA0XLAjtKItc0L9yJW3MZscG\nNTXV/QtfQXle9abqT5+ml4bf9VfLsWPk698tZs/DxYviBn9OnXJWTz74wDyOEXPn2u+wOumAKWzc\n6KxTf+YM1Xun2Mnztm30rDidoVdYupTe43aw47hBD2U/DzsK4q+/upMJUNuXlkbtuZUO55gxzmbS\nFJRZMLuzz5zTLJqoPXlGjw7dU0Qty83shZo5c9zN+igmnl7CeaB/s2JF3H/957vvDq9Vi+g2rwNQ\niTFWHsBRAD0A9FRHYIyV5Jwfz/7eCLTzsSXddfDg4LurLCpJSQl1T7ljB9lrinQRd/SovcW5586J\nWUQ0YgTtVnnPPcZx3JgYGMl86SVr3pdETUdauVZnzojfbXLNGnoxPfCA/siT4orRrscZI1JTSYFV\nNr4z4uRJMfK0bNpEoXBhem6Uhb5nz3rTIbeC1562tm2jetqpE9mB79wpZkZAQXnBJCQE9j4IR1ZW\nYO2KSPbvp3anUaPAsXnz6LhI1q+n+lu9uvX/TJ4sNg9GjBolZuTv6FEauTNre7VoN29zwpgx1hbB\ni3puRo0CXnyRPLZYgXMavfYLRZaI/V3S0ym9m28297SmXbjqhMuXaRAxUhtXbd5MA20PPWS8Yasb\nM0ctdmdvjh4VYwqrJT6e3utNmgSO/fmnPQ+EXnD5MikCokwI58yh+6q3aeHs2QEFulmzODRrFvff\nuSFDjG+Ua2WAc57JGOsPYDECrkV3MMb60Wn+JYCujLGnAWQASAHQ3b3c4N+XLwc6bna8HIhkyxZ3\n9uVaVq+290ISwaJF5ouXDx92ZwOsJiuLGoZSpfQblMuXSevPm1eMPAWlcWjbVn+jmLVr3dsPq/ns\nMxq9NFqApGjzXm84opiwNWxInoas7KjsBEWZvf12/fPbtgV2gfUKpY1wsz7ACmfO0Ohjs2bhZyWX\nLfPGnlwxoalenRS906fFejxSUEzJrC6iO3ZM7G7c586RMqLnIUuEIqBm82Z7ba+TxdF6xMeHVwbO\nnRPbFo4cCQwebK0zt3t3YKMvN3z+Oe3rYLYHi4gNMdUoI+9m9dfOAl4zrGxcNX++eDffSjvz55+k\nqN52G1CkCB3LyKB6ZGehuxlbttB1698//IJtzslU1+3MixGKFUe9elR/ChRw5lDADGUmxKr3vAUL\nnHl8NEIZ3NNTBpwOeAkxqOGc/wKgqubYeNX3sQCEjol98gnQuDH5VD96lDqxXm6CoTxcygOlh0hF\nQOHIkVDvFklJ3pn0pKdT41G2rHHHRsS0v8K6dRTatQse2VRQXvJe7f67bh012A8+GOiIcy7eg5Bi\nM23kDeuff8iOV/QL0AgRL/VwXLpEL18jZcBrRcBPFIWqcGF66eqxbl3A84dXXLrkzPOKF5w/b22t\nih0+/ZQ2G3z++cAxr9pCOyOdTr1w6bFqFbkQ1JvdTk6ma1Cpkjh5ACmOVtqdxEQx8o4fJ1MLo055\nRgaN7nq1w/iWLeSn3sleLE5ITCRZRrPCokw0jWQrgTGawZw7F7jpJrFyFDv6zZuBpk2N4x0+7J0i\noGbKFKpn/ft740BDadusDIwsWSJmtsmMjAx3gyJX7A7EWVk07aeethQ9OqTm449pOvXFF72ToceX\nX4ZWuJEjvZOnbHxkd5rcLXv26CsDXoxwqvntN/qMjydby7x5aVGUSH/Cavbto86L1ue2smBNhIlZ\nTuKnn2g6s04d+h0fL36WJ6dw+jTZ39aqFaxInzjhbsGmVUR3vo1YvJiU2tatjeM48cRiBe3CSK/a\nwnPnyAzzgQfMN3USbWa3dCnQpUvocWWWJSFBrLxVq8jstl074zjJyf6ZCC1b5q0sZdDuf/+jDrKi\ndMTHe+NpZtIkGi1/4YXg435uSKq4MFZmKkQpdlrOnaP6dOedoQrmqVP+DVQoJkiffeaPPCNWrPB2\nXeS4ceRCvF07GihwMxN7xSoDkcBooeDGjeK8segxbRpp9IULezdCrmXXLjI5qFkzsIZg1SrxIwoK\nly7RtGXLlrSJSXo6mT9Uq+aNPC3aKVORo31qFH/FVatSh/HkSVrY69UoWKTZti0QbrjBvZeOnIwy\n23LhAilA119Pvs69nhHwG2UmxEgZWLvWG3tghT17aJDA670TEhJIqenXzzjO77+Ll7tlCw1G3H47\nkC8fHduzJ/BdNMqC4ObN9ddmJSV5o3QpAyNaUwcnrpidMHQo7QVQvToNULjxqmPG2bM0KFCkSOAa\nf/mlWGcnOQHF+17u3KQQKBw86M/iWb85dIgUab11Gdu3u9sryAonTlBo3ty9SSbjfqqnNmGMce0C\n4khTtSrQvj091JmZNBvx/vuRzpV3FCtGZa1WTYy3AzOKFqVQqZJ7N6I5mdtuo+lhp/7CJTmfokWd\n7XZ5pfDSS9T+qWfR/FgL4jcDB+qvKwLEbkKkpVYtUqCvvZYGK3Ln9nbm8IEHaBCkRYvgwYkffvB2\n48W33qJO8dGjZE6xe7f9XcivFAoXJjOaYsWuPBfkdrjxRhrQu/9+GiTJm9d709RIom0H9u71z3mC\nHYYMYeCc6w49SmXAIfXq0ZSblyNgEolEktNRXoQnT3rjLSnSMEYKgXpknnMaFYzG0c5+/ajzlicP\njfTu2yfeM5Wa1q3J69eRI/6azkgkonj4YVqbUKsWmbiJ8kIoGqkMSCQSicQTatakGYFo5/HHabYn\nf37g3Xejd0bvppvIpjxvXv/MUiUSifeEUwaEWKwxxtoAGImAa9GQ7VcYY6MBtAVwCcCjnHMf1ldL\nJBKJxEtiQREAaJMkgOyDo1URAAKLS6UiIJHEDq69mjPGcgH4DEBrADUB9GSMVdPEaQugIue8MoB+\nAHzyeyGRSCQSiThE7w4ukUgkkUbEFkeNAOzmnO/nnGcAmAagoyZORwCTAeD/2TvvMCmK9I9/391l\ngSXnKCw5p3VBJAgq4GFCRQU8xRzO7N15prtjMZ3eTz3Tmc4Ed3pGDGA4EQXFhAiCSEbARFKUHJbd\n+v3xTtHVPZ1mpmc2vZ/nmWdmenq6qjpUvaneUkp9BqAeEWUoy68gCIIgCIIgCG5EoQy0AmCun/d9\nbJvfPj+47CMIgiAIgiAIQgYp91luJ0+25joMGzYJw4cXlV1lBEEQBEEQBKGcM3t2EebMmRxq3yiU\ngR8AtDG+t45tc+5zSMA+rkg2IUEQBEEQBEEIz/DhRTYDumlcdxJFmNDnADoSUVsiygUwHoBzLb/X\nAUwEACIaCOBXpZRk6BcEQRAEQRCEMiRlz4BSqoSILgfwDqzUosuI6GL+WT2mlHqTiI4lotXg1KLn\nplquIAiCIAiCIAipEcmcAaXU2wC6OLY96vh+eRRlCYIgCIIgCIIQDVGECQmCkATZ2WVdg8ySm1vW\nNRAEQRAEwYkoAynSq1dmyhk0iN+rV89MeUL66duXr+sY56oclZQRI8q6BoIgCIIgOBFlIAVOPx0Y\nMiQzZQ0bBvzxj8C4cZkpz+Tcc4EGDTJbJnlPek8bw4ZlvsxRo4B+/TJfbiaZOBE47jhgwADgssuA\nzp3LukaCIJQn+vcv6xpkhmrV+L1167KtR6bIzwfq1CnrWghhKPfrDARxwglArVrAnj3Aa69lpsym\nTYELLuCwh59/Tm9Zo0ZxB1K9Or/27ElveU7OPhto2xaYMAH47DPgm2+AX35Jb5l9+7KA/OGHwOrV\n6S1L89e/sgKyaROwciVQWpr+Mp1hM9nZQElJ+spr356vX+vWwPffp68ct3Lbt+fPTZpUfu9Wz57A\nIYcAX3wBbN5c1rXJDIWFwE8/AevWlXVN0kv//sBXXwF795Z1TdLPwIFAjRrA7NnpLysrZpbMyQEO\nHEh/eZpq1YDi4syVd+ONgFLArFmZ7YPLgtq1gXPO4c9FRWVZk8ySlZUZ+SFqUlIGiKgBgOcBtAWw\nDsDpSqltLvutA7ANQCmAYqXUgFTKBVjj7NPHblXNlDJwyCGWINewIdC7Nws5s2ZFW87gwVZ4kKZJ\nE/ZI1KgBTJ0abXlutGvH702bsuL10EPpLe+vf7UGhrZtgQcfZCEj3egyx4/n93R2Xv368YBwxBHW\nthtv5Pfbb09fuYWFrNQtW1a2A9HIkcDu3TwIf/tt2dUjHfTuDZxyCn8uLORB4bbbyrZO6aRHD/b0\n9OrF99STT6a3vLp1ge3buQ9ctowF80xy3HFsrPjkE2DtWmDXrvSVNXYs0LIlG0W+/DJ95bhxzjk8\nxgKZUQaqVQNuuokNMrfemv7yNKNHs2K3Zw+f53RDxK/+/YFFi4CaNYEtW9JfbqY5+WTLAARwiOjq\n1ZXbWDBoEI/rjRsD06eXdW0SJ1XPwPUA3lVK/Z2IrgNwQ2ybk1IAw5VSkdmUtcZpct55bNl9442o\nSrGjB6KCAmsbEQ/+27ZFrwx4zUfo3p3bmW5++9v0l2HSrZsllGvGjwfmzAGWLk2f1TzTE3kbDS8D\nwQAAIABJREFUNYoPL8vE5NqsLB50e/UC6tcHfvwRePvt9JV37bXA/v3x2+vWBc46C3jllcqlDPzl\nL/b7NzubX8ccA/zvf2VXr3TSvj0bZQCgXj1+r1MH2LEjPeUNHMgKSL163F+0awfk5QHPPZee8kyu\nuorfW7UCTj0VuP/+9CkD48cDXbvy5xNP5BDGRx/NjEfiiiu4j8oEhYXcrw8ZYoXQZIJjjuF7tG9f\nfmY//ji95bVube8L69fnsN93382MMtC4cWaMagB7fnWfoBkyhF+V0UNw2GF87w4bxu9K8TX99NOy\nrllipKoMjAGgI62nAJgNd2WAEOH8hMMOc9/epg2/Zs9OTyddUMAX3C2ePUqBsk8fYOtW9gJ4oWP4\nu3dnQTkddOoUv619++hCH/r0YetI8+YsHOblxe/TuDFbyDZsSE9n1qwZWzEyiVs7NdfHnp477oi+\n3Lp1+Z2In5ONG6Mvw6RWLX550aEDX/+oOfdcHnh37AC+/hpYsyb6MkzatWMh1asPOPzwyqcMDB3K\nHlKzj6hXD7j8cvb4PPqo939ToXZtS+kg4j75xx/TU5bJTTfFC6tKRV/O4MHA0UfblcqsLO7va9XK\njDKQKUVAl3X44fZtEybws/Sf/6Sv3ObN7eXWqJG+sgAOK3a7XwoLgQULLONM1OTn83hzwgncJ/7j\nH9GXYXLoofHX06Rjx8yF/qabZs3YKHvYYRwhoiFiZfPnn4FVq8qufomSqjLQVK8krJTaSERNPfZT\nAGYSUQmAx5RS/0qmsBo1gEsvDZ6QctllwL59wH33JVOKNw0bek9szcsDWrTgAXLevNTKGTiQj+VH\nbi6H1ADAzTfzALktLkAreW64wX37iBEsAMybB6xYkVoZJ5/MD1KjRsFx5OPGAR98ACxfHm2M5+9+\n5779yCOBX38FFi5MvQwdlzpmDHuWnFYTk3QMSqefzuW3bGnfroWqqOnfP5yg1LMnu+ffeiva8tu2\ntT4XFKTXGtWgAc+rCeLss4HPP0+f4j54MPDRR6yYrF2bnjIADhfcvJktqm5CY+PG0fZDmlGjOLSs\nZ8/43/R4UL069/tR06+fu9V65EjghRdYSI/K+DRypPdvEyYAc+eygpuuOPcjj4zfduWVLEg+8kj0\n5bmNc126xG+LGuc43qcPG5vq1k2ft9RNdqhfH/jTn3g8TYcyYEZQ1KwZ/fFNmjRhpcOPceP4Gb3r\nrvTWJZ0Q8fg2bhyPoW5GICKOrPj5Z+CBBzJfx2QIVAaIaCaAZuYmsHD/Z5fdvUSAwUqpDUTUBKwU\nLFNKzU20ss2aWdZNP/Ly+HXuuTxhcu9efthq1uQBJVEGD+aL7jYQabKygIsv5k4zVWUgrJdBW4+u\nv55vvr/9LbVyNSed5C2c5+SwRTfVNmqcAqoXTZqwh+C991gpiAK/86wzC6WiDGjBadw4vvdatQr/\n3/PP53MdhYW1QQP3QbdzZz6nRMBLL6Vejua448Ltl5XFyuDWrTw5PVVOPtndUDBgQHT3q6Z9e7a6\n9e4dbv927fgVlWJCxNf1mGMs4Wn4cD6nS5eyBf2DD6JTDPLzWVj57W+5D/bL9pWOcI/mze0xyCZ1\n6rBSX6NG9JZPN4+Apnt3vp7/+U9mrJ2NG3PfvHcvG0Wi5oIL3Pso0+qZKkcfzQaAYcM4EUXz5t77\nHncc7/vee9GVr3F6LLOzWeFM1cDlZMSI+NBXN3r3Btav5zlGy5ZFWweTU07hvjDKOWO1a7MBM0ya\n9WrV+JWb6x5Cmgo9evA417x5erxK9euzgfCyy7gNYYxptWtHX490EagMKKU8bRVEtImImimlNhFR\ncwCuASRKqQ2x9y1E9AqAAQBCKQOTJ1ujzk03TQJQFOZvANhCqK2Eo0dz2MD27RynF2aQHDqULT7D\nh4cf4MI8+EEkqsFra/Lpp/PA+MQTyZd9zTXhbvJU4vfHjQuvBDgZPpytOE8+mZo1rl49jvtNF0cf\nzS7gH39k5SlRDjkkurp4KXZE3IEnI8hMmMBCfKNGwJIlfN8NHMgKTKIMHBiNMuDlcTn2WB7oE5mY\neP75bMnv1YvnAo0axdmBhgzhgbRHD/9wr3TTqBGH5JjoPkoPyvn5bMHat48nvH7/PVuqtm3j52jJ\nEnbpf/89D1qLF8db9fWgPXo0K+Rh+re8PO6L6tYFHn881ZYyQd7gZjFz1YgRrCS9+GI05Ybp96Oa\nyxQ2y9ZJJ7Ey8NlnHD4ZBVlZ6U932agRj6kaP0UAsNKNzp4dXXaWM87g6+UVghtV6FdWFhuDwqYe\nr1EDOO00fk6jUgZ08g+T3r35FYVRQnviDjss8RTrV1wB3H136nUA+D4aNYpDX3Ny+F5p1oyNJKkY\nDvPzecJz27asqF1yCWe6SkTAj0Ie9OKUU/he7tKF57y0bMmeylatgB9+4H1mzy7CnDmTQx0v1TCh\n1wGcA+BOAGcDiMvnQ0R5ALKUUjuJqBaAUQDC1Q7ApEkKTZqwNpYqderw67e/5Yu6Zg17Dr74wlln\n7hS6dk3MmgtY1mZtFU6Es89mz0WyeXm7d+f3ceN4EP/3vxP7/x/+EL7sNm2St4Z165bc/wB+uBo1\n4gHxpZf4OiY6GNevD1x9dfJ18EOHa3XrxkpdMoqAyTHH8IOezITMY4/l/wWtEZGMMGO68lNdN6BB\nAx5M5ibsK7SoX9//95wcK7VqEEcdxcqYVsh0XLy2TAeF8KWTRo349ZvfBO+rM5fUrMltAtjSumsX\nW5mHD+dthx7K70cfzdbajRvZGqyVni1bLGE7LN27R2P5mziRQ2L85k+ZDBnCfXffvlbIVJs2rNjl\n57OwFSak8o9/DL/WSdOmqXtgLroofNhejRrcvpYtgRkz2MD166+ple8XnqRp0iS1ya5uc9DCcN11\nLODdeWfyZWvq1+fr5UUqwtsNN7BCXbs294nJHKtfPytFbyppy3Wq7HRw7rnsnWrXjp9xv3lhXkS5\n9kCLFnavYVaWFf6biDLQqBEbMI4+mvuH7t1ZvsjJ4T4omSQf1apx31uvHifMiILTTuN69eplXWO9\noOf117OS9sUXPK6PGlWEd94pOvhf07juJFVl4E4ALxDReQDWAzgdAIioBYB/KaWOB4cYvUJEKlbe\nM0qpd8IW0KULX5woycnhV48e/OrZky0thx/OnV3r1jwgJqoIAHxxbryRb8hEU6Q1bZrcg+WkWzce\nEAcO5EF/xozg/4wcmdgDOngwn6fFizOf9g7ggeWGG4CXX048vWAineSYMZzxJmy4UGEhn5uoLAKH\nH86vZCw5HTqEmwyovTRdugS7yQcPTs86AQMGsPWluDjxic2//324uRbjxrGn5sUX3cMF8/M5NKFx\n48TKT4TLLmMhO9k0yG3apLZidc2a/p7HBg0s5VErAMl6qaJ4Bsz6hIWIjQWA5S3SGeC6deN+7r77\n3Nf1GDiQFaFErH9HH83WydWrOZ4/GZLxlDZtyhn0du7kjGvbtycX5nLjjeEEnd/9jp/PZMNRk/Wk\n6f7mnHP4eiVq5EqkDh07WnP2EhXeqldPffG0GjU47n7uXI5gSJagZ69Xr8THzb/8JT60NpUseFde\nyWPrq68m938dptmjh/c+ffpwP/ZOgMQ5ciSPbRrtJdOewVTaecQR0Uz879ePr1mnTt710eNgYSG/\nK8X9UufOwRkoU1IGlFJbAYxw2b4BwPGxz2sB9E22jAkTkq5eaHQ8L2BZGN1cbGFJ9MapWZMtdlFO\n8CFi66FSHM7Rpk18+r3Ro1n58JsL4UV2NmvjS5Yk9r+oQyuOO47bNndu+ImLbpPkvOjXj19hlYGs\nrPS4Brt2TTxOOGxoW5063NFv3RosTISxICZD3bocmvPRR4krA2HmEQE8WLdrx4Liyy/zILJggeVW\nLSwMb4FOliZN+JWoMtC5MwvlAwemp17pICeHvVNNmwJPP53Yf/X9HvXqpW3a8PvVV/PAOW8eC361\navH9kUwmndxc7iPWr4+2rmGpXduKr1+yhOsRtl8+8sjw41VWVnKGgJ49ebzwygIYFr3uwcCBHJ6S\nyHyu8eP5P0FKXlYWj5uZSN3tx4ABySsDYQyKJ5/MFuuHHw7nwatfP/oU3A0bAvXqleCJJ5JL91av\nHl9Pv+dOKwpeXpYjj+T/N27Mi42mi/37U1+gtk0b7hfDrtXQoUMHZGdnY+LEcPtX+BWIyzt60okf\nl13GbtB0CJFEHE8HsHuvTh2OSWzaNHm3rUkikwXPPjt6YatGDbbGFBcHa/+//S1by9MZx5euNQvG\nj+dsHmEE5XPO4Y4nrJAMpH/147Ak4rU544zkJjd27sxepeJiFlTy87mzTnd6QZMxY1hgC5v2tHt3\nDg2paAxIcnnJsWNZmUhXqIM2+pgL/6VKq1aJe0nHjYuuT6xZk/vC3r25b2/ZEpg5k71g5oTRIUPY\n27hvX+JeF8CKpQ5L8+aJx5T7oUPkElEGmjcPDiU0SXSOQtT3aW4uT+hOdM7N5ZeH82rpdLVh650u\nI8SaNWtw/PFr0S4V62sIrrjC+7dkjKGJkpvrX4eoWRuLW+ycQAyvKANp5M9/5ofu5pv998vLS6+A\nqtGTqU13WKoMG8Zu6pyc4Jzx6XzeBw1il2B2Nis7desC//2vFVs3dmxqxz/tNA4BCEoNGeXEXycX\nX8zvkwNm3BxyiGVFSwStPLRoEd3ExETp2JGVury84Mxfqc5VqFbNijXNpCIAWB6noPCvAQM4xCXR\nmP3yRp8+LHwErWY7ciRbZTO5AFVUHHoot3HZsvh5aF6kMn/KC3PRpzPO4Ofok09YATA9s8mGpJ56\nKs87efjhcPunYz0GgL0727f7r3qtJ7km+nwnYtS57rr0GIFat+Z5fPPncxhYEDVrJh7iOHy4/xoo\nTZuyES1daagBoF27dgkJrUJ6EGUgjejMKh06cIe4eTMLzpqJE3myUCYUgXSRl8eC8mefeSsDjRuz\nsJ5u9ODWrx+/X3MNT76NQvnR80u8hLeTT2Y3XjKWtrBoK45e7MTJUUexBTDZ+ykvj3NeE8VP1rvm\nmsyskty0KadzXLgQePNN933q1Ene4lze6NbNPXuInr9RWOg/4bGioBf227KFhZb58+2/5+cD330X\nraEi02RlsTKbkxNeGcgEeXnRzrurXTuc9Vkr9FF4oN2oX59fv/89cO+97tb8a65hxSVRZaBJE56U\n2aJF8ByFdObvr1MnnIHpssuSS2N5+OHcx9x/v3eSinQqAkL5QZSBDHDWWfyuswstWMBZO9q3986d\nXdHQK4GWlsZPTHKmQMwUtWqlL8Zdo+PN27ZNzA2dCpdcwuf5llv4+9ChPElo6NDU3dV5eay4FhRw\nm/Lz2UqbyTSa1apxqMPKlTwof/IJbz/0UFb00p0CMZOcdhoLTLt3swA5YAArAQMHWtmAKhOnncbv\nxcUsPH/9NYdohVm4raLQti33eUuXeufIP+KIzCyuVZYccQQ/s+n28tSty154pYBnn+XQu7FjWfGs\nUSM5rx8RhzZFtZhcKnTowB6eHTuA6dPd90kl1KxaNe53Zs2K/01PRBUqP6TS5cOLACJS5bl+Qjwr\nV3KH3Lgxez169LAEgMrAqlUseOu8+BMnsnCaCau5k82bOUuBnhRZGSkpAaZNY6GisijOgkVxMSu2\n6chQVdZ89RVPVDfJz2fvR7qs5Znkyy/Zq+WVdOD44zMvTCrFr6i87fv2eWdPOuUUFqTTEerlxooV\nHPqq6dSJUyUPGZJYUgw3SkvZIDFvHqfjPPZYDq9N96rFK2OzdiVMKFq8zisRQSnlamJKSRkgolPB\nq4B1A9BfKbXAY7/fALgXQBaAJ5RSoTIGizJQ8VCK04W1aGHlIK5s1k2Aw3G++oons1XG9gmCkBpK\nsXegVSvgmWd4flUmJitmGmfopJ5zdPnl6U3TmylWr+ZQmX/+kw0/ejJ2VKuJh6W0FHj/fb6H8vKs\nsTXK8ae0lK9dy5aZGdfKizKQnZ2NPn36oLi4GN27d8eUKVNQI8mJZHPmzMFdd92F6dOnY/r06Vi2\nbBn+9Kc/ue67bds2PPvss/hdbGGEDRs24KqrrsILL7yQdFuAslEGugAoBfAogD+6KQNElAVgJYCj\nAfwI4HMA45VSgYkSRRkQBEEQhPLLypU8x2fECJ730acPG4Iqm7dn61a2lM+axfN4Ksu8pbKkvCgD\ndevWxfbt2wEAZ555JgoLC3G1Y2VSpRQohIY0Z84c3H333Xj99dcD9123bh1OOOEEfJXoog8BJKMM\npORMU0qtUEqtAuB3hgYAWKWUWq+UKgbwHIAUls0RBEEQBKE80Lkzp0ht1IjT3xJVPkUA4DTGNWty\n+JMoApWXoUOHYvXq1Vi/fj26du2Ks88+G7169cL333+PmTNnYtCgQSgsLMS4ceOwO5by7u2330a3\nbt1QWFiIadOmHTzWlClTcEUsp+jmzZtxyimnoG/fvujXrx8+/fRT3HDDDVizZg0KCgpw3XXXYf36\n9ejVqxcAYN++fTjvvPPQu3dvHHrooZgdS8U2ZcoUjB07FqNHj0aXLl1w3XXXRdLuTEwgbgXgO+P7\n92AFQRAEQRAEQRDw5JOcLjZK6tbllbr90BEoBw4cwFtvvYXRo0cDAFatWoV///vf6N+/P37++Wfc\neuutmDVrFmrWrIm///3vuOeee3DttdfioosuwuzZs9G+fXuMGzfOdmztTbjyyisxfPhwTJs2DUop\n7Ny5E3fccQe+/vprLFjAQTXr168/uP8///lPZGVlYfHixVixYgVGjRqFVatWAQAWLVqEL7/8EtWq\nVUOXLl1w5ZVXolWrVimdp0DPABHNJKLFxuur2PsJKZUsCIIgCIIgCGXInj17UFBQgAEDBqBt27Y4\n//zzAQD5+fno378/AODTTz/F0qVLMXjwYPTr1w9Tp07F+vXrsXz5crRv3x7tYxkuzjzzTNcy3nvv\nvYNzA4gIdQKWV587d+7BY3Xp0gX5+fkHw3+OPvpo1K5dG9WrV0f37t2xPoLlzwM9A0qpVJMz/gDA\nzHfSOrYtFGaM1qRJk1CU6Vk7giAIgiAIQloJsuCni7y8vIPWeZNaxsp8SimMGjUKzzzzjG2fRYsW\nIczc1jDzDfwwy6huxOFlZ2fjwIEDrv8pKirC5KBVSmNEudyVV0s/B9CRiNoSUS6A8QCCZ1bEUEod\nfIkiIAiCIAiCIESFlzBvbh84cCA++ugjrFmzBgCwe/durFq1Cl27dsX69euxdu1aAMB/zfyvBkcf\nfTQeeughAEBpaSm2b9+OOnXqYIfHam9Dhw49qHisXLkS3333HbokuDhJUVGRTYb2IyVlgIhOIqLv\nAAwEMIOI3optb0FEMwBAKVUC4HIA7wD4GsBzSimXNTcFQRAEQRAEIXN4We3N7Y0bN8bTTz+NCRMm\noE+fPhg0aBBWrFiB6tWr49FHH8Wxxx6LwsJCNGvWzPVY9957L95//3307t0bhYWFWLZsGRo2bIhB\ngwahd+/ecROBL730UpSUlKB3796YMGECpkyZgmouK/il6nE4eJzynLpTUosKgiAIgiBUPspLatHK\nRsZTiwqCIAiCIAiCUHERZUAQBEEQBEEQqiiiDAiCIAiCIAhCFSUTi44JgiAIgiAIgg2dhUeIjrVr\n16Jdu3YJ/UcmEAuCIAiCIAgZpaSk5GCqTiFaOnTogOzsbNs2vwnEthykib4AnApgCYASAAU++60D\nsAjAQgDzEji+qmpMmjSprKuQVip7+9yoam2uau3VVKV2V6W2mki7Kz9Vqa0mVandVamtJjGZ2lXe\nTskzQERdAJQCeBTAH5VS8Uu48X7fADhUKfVLgsdXqdSvIhLT3Mq6GmmjsrfPjarW5qrWXk1VandV\naquJtLvyU5XaalKV2l2V2mri5xlIac6AUmpFrICgVQ8IMllZEARBEARBEMoVmRLQFYCZRPQ5EV2Y\noTIFQRAEQRAEQfAh0DNARDMBmOsrE1i4v0kpNT1kOYOVUhuIqAlYKVimlJob5o9RLbVckajsba7s\n7XOjqrW5qrVXU5XaXZXaaiLtrvxUpbaaVKV2V6W2hiFQGVBKjUy1EKXUhtj7FiJ6BcAAAIHKgFds\nkyAIgiAIgiAIqRNlmJCr4E5EeURUO/a5FoBR4AxEgiAIgiAIgiCUISkpA0R0EhF9B2AggBlE9FZs\newsimhHbrRmAuUS0EMCnAKYrpd5JpVxBEARBEARBEFKnXC86JgiCIAiCIAhC+pB0n4IgCIIgCIJQ\nRRFlQBAEQRAEQRCqKKIMCIIgCIIgCEIVRZQBQRAEQRAEQaiiiDIgCIIgCIIgCFUUUQYEQRAEQRAE\noYoiyoAgCIIgCIIgVFEiUQaI6Aki2kREiz1+H0ZEvxLRgtjrz1GUKwiCIAiCIAhC8uREdJynADwA\nYKrPPh8opU6MqDxBEARBEARBEFIkEs+AUmougF8CdqMoyhIEQRAEQRAEIRoyOWfgcCL6kojeIKLu\nGSxXEARBEARBEAQXogoTCuILAG2UUruJaDSAVwF0zlDZgiAIgiAIgiC4kBFlQCm10/j8FhE9REQN\nlVJb/f5HRCr9tRMEQRAEQRCEyo1SyjVkP0plgOAxL4CImimlNsU+DwBAQYqARqmqpQ8QUaVuc2Vv\nnxtVrc1Vrb2aqtTuqtRWE2l35acqtdWkKrW7KrXVhMh76m4kygARPQtgOIBGRPQtgEkAcgEopdRj\nAE4lot8BKAawB8C4KMoVBEEQBEEQBCF5qDxrR0SkynP90kFl11gre/vcqGptrmrt1VSldleltppI\nuys/VamtJlWp3VWprSaxdru6B2QF4nLGpEmTyroKaaWyt8+NqtbmqtZeTVVqd1Vqq4m0u/JTldpq\nUpXaXZXaGhbxDAiCIAiCIAhCJUY8A4IgCIIgCIIgxCHKgCAIgiAIgiBUUUQZEARBEARBEIQqSiTK\nABE9QUSbiGixzz73E9EqIvqSiPpGUa4gCIIgCIIgCMkTlWfgKQDHeP1IRKMBdFBKdQJwMYBHIipX\nEARBEARBEIQkiUQZUErNBfCLzy5jAEyN7fsZgHpE1CyKsgVBEARBEARBSI5MzRloBeA74/sPsW2C\nIAiCIAiCIJQR5X4CMREdfBUVFZV1dQRBEARBEAShXFNUVGSTof2IbNExImoLYLpSqrfLb48AeF8p\n9Xzs+3IAw5RSmwKOKYuOCYIgCIIgCEIKZGrRMYq93HgdwMRYZQYC+DVIERAEQRAEQRAEIb3kRHEQ\nInoWwHAAjYjoWwCTAOQCUEqpx5RSbxLRsUS0GsAuAOdGUa4gCIIgCIIgCMkTWZhQOpAwIUEQBEEQ\nBEFIjUyFCQmCIAiCIAiCUIEQZUAQkuDTT4FXXy3rWgiCIAiCIKSGKAOCkARvvw18+SWwd29Z10QQ\nBEEQBCF5RBkQhBQoLi7rGgiCIAiCICRPJMoAEf2GiJYT0Uoius7l92FE9CsRLYi9/hxFuUI49u0r\n6xpULn7+2fp84EDZ1UMQBEEQBCFVUlYGiCgLwIMAjgHQA8AEIurqsusHSqmC2OvWVMv1YssWYPfu\ndB294rFxI/C3vwH/+x8giZmi4YEHrM9r15ZdPQTBDaX4vty/v6xrIlQUliwBXntNxgih/LBvH8sv\nVYGVK4GdO8u2DlF4BgYAWKWUWq+UKgbwHIAxLvv5r4UcAXv3Av/8J/DQQ+kuqeKwZg2/f/IJ8OKL\nZVuXysjrr2duAC0t5VdF4LXXgH/9q6xrUbHZtw/49tvE/7d6NTBlCvDSS9HXSaicvPQSsHAh8Ouv\nZV0TQWAefxx45JHKf09u2AA8+yzw2GNlW48oFh1rBeA74/v3YAXByeFE9CWAHwBcq5RaGkHZNnbt\n4vey1rDKE1mGurc08jMuAHzf1a6dvuOXlLBgvXEj0LQpcOml6SsrKhYuLOsaVHxefJEF+7PPBtq1\nC/+/RYv4feXK9NRLqLzIHCihvLBlC79v3w7Ur1+2dUknOox7+/ayrUemJhB/AaCNUqovOKQoLUkZ\nJbOLHaU4PKgqUJaD2J494ffduZOFNK24hmH7dstdunlzYnUra0pKyroGFZfVq/k9EcWquJhDPioC\ne/bInJvygBnqKGOoUN7IquRpbsrLGBnFaf4BQBvje+vYtoMopXYqpXbHPr8FoBoRNQxzcCI6+Coq\nKvLdd/HiRKpd+dm6NX5bIoJrReHjj4Hbbwd++in9Ze3YEb8trCKydStw113sEnz44fBlVmSBSSyN\nyZOdze+LFwObNoX7z3ffBe9THjhwALjnHuC558q6JoLpSZdkExWbl14C3nuvrGsRLZT2APOyxVTA\no47eKCoqssnQfkShDHwOoCMRtSWiXADjAbxu7kBEzYzPAwCQUspFVI1HKXXwFaQMfPZZolWv3LhN\nIPzPfzJfj3TzzjvsBXnwwfRr2f/+d/w27c4M4qmnrM+JhLJVNIHazLb01luZL18pPtfTpkV7zIUL\nMyssmRaxsIqu04r21VfR1SdK9u7l+1p7P4Syw5zzVFGUgWXLgPffL+talC+UYq/gBx+UdU1Sx5wn\nkKgyoBTPlSwvFnc/lLLP5XzhBff9Nm1KTlEoKirCggUKr76qUFrqP7kxZWVAKVUC4HIA7wD4GsBz\nSqllRHQxEV0U2+1UIlpCRAsB3AtgXKrlBiEZhdyVgR9+iN9Wkdm2zf7dtKCWlAA//hhteW5hOq+8\nEu6/bl6FMDg9AytWJHecTPHNN9bnRYsyn6GktBRYv54t6lF5VT79lCdFh73WUWBOFg+rEDqf+Zdf\nDv7P5s1AUREweXLoqqWMKXQ+/LAYcqJkyxa+np9/Hm5/c6zU98+WLdGFJC5eDPz3v9EJZ5s2Ac8/\nD8yZw0pBWbJrV/kJrTLPb0XPCrV+ffL//fprNtq9/nrwvmVN2IxvDz/MikIyyvprr7EhK6isSKKx\nlFJvK6W6KKU6KaXuiG17VCn1WOzzP5VSPZVS/ZRSg5RSaen669SxPt93XzpKqFiUl05EV+cnAAAg\nAElEQVQqnTz7rP272ea33uIZ+ukKH+vSxfqczEB3773h9nMKgv/9b+JlZZIcR1qCefMyW76pACxY\nEM0xtWC0fHk0xwtDq1bW57CDRjLPvM6+plRyXqjS0sQzfpgWsE2bysaDVN7Yty8agVnPMXnjjXBe\nS3OOiba266x88+enXp9p09iAEZSG+csvObOKH/v320Msowqr+OWX5ASt//s/4I47oqmDRin2didq\n9PnyS+tzInPSyht79tiTHySaQU/31TqRQnkmzHUylfJU0kUHeYkr1dQMM6NL1O5OpdjaUlQU3GGV\nF7zmB2Qitj5TOGOptTCzZo01kE2blpilZNu2YKHo+OOBYcOs704hzFme20MfVoCqaHMGnAJNpt35\n5rWLShE0J/GGvR4HDrBR4rHH7AN1WMxywvZnbspAIvf+bbclblW8+WZWbN98M/x/ws6BqCp89x2v\nB2OGEiaLGSq2bl3w/t9/b33escMufMyYEZ1g6aeo7t4NvPoq8Oij7H3zut+nTLF/jyIM7rPP+Dl9\n4onkj/Hhh6nXQ7NjB8+DS9ToM2OG9bmihHu58cEHbN3XJKoMBLW9uNh+z5clYSJYzFT5qYQMm/eH\nG5VKGUjnA/Cqkf/I7yHV4QnlYbEMr873wQczW49MojVnZ+xd2Njk7duBf/wDeOYZ999r1ADq1QMK\nC4Fq1azt5kNaUsIhF0VFlmBshs4kSjpiQEtLOYygqIgHnlSO88ILdgudU3ioXj354yeDOYGuq9vy\nhykSNqRl61a2OP74I/cfiQxqmzbZQ9xmzQonpGvhr0ULa9svv4QvF0jMu2DWKdMeoHRTUpK5hdu0\nIPr999baMMliXhOzjwpD7drxGejuucf/Pzt2cD8SlBTB7/43Fd9Fi7yfsajDXA8csLxSmzcn9oya\n53nWrOgy982d615G2LoAyQmNBw6wp72sUxI7kyAkqgwE9c+vvMJrGKT6nGl27AjXT6xezc+JeQ/r\nsXLECI5sIfK/5lEqnU4qlTKwfz+Ql2d9jzJuznQ5devmvZ+euPjII6mXqQXJvXuTa4vpGRg0KPX6\nlDfczol+KM37AGDhPoxLWef6dbOobdrE10LPU/BSBszJwStXcj29YrfDzCNIxzyP+fM5jABgl3QQ\npaXuFvENG/i8msqXvgbHHsvvznkdqVJcDHz0kXcHbIYGecUUb9/OHXOYMAjnwBp28veTT9q/JyJk\nu8W7BoV8HDhg3eNnnplcuUBiGcdWrbJ/rwiT9rxYuNDu9X34Yc5SlomF/sz+6t//Tm2u00cfWZ91\nRionxcV8Hx84wAJIfj7ncs/OBjp0sO8bdE11RqhNm/wVz9JStuS79WfOe+6996xy9+zx93AUF1uv\nRHn7bfv3m28O7zl3lvfJJ4mX74apVE+eHE7QdBpggkKMSkqAO+/kPlCHia1Zw+OVM/Q20+Tm2r8n\n8vw571W3vk/3kWGesa1buQ8oKmIPt1Pm2L8fuPtu3icInbzlX/+yQjL12FirFq8hpJT/85bo+j2J\nzKmpdMpAvXrW97/9LZrjOgdhL6Hyiy+iKU8f65ZbWKC4447ErW6lpTzBCgCGDAFGjQKGD7d+dwp2\nv/zCN/zLL1vhUFGjFFu5o5rU6/ZgaCtP27bxv4WZgON0Q5u8+679uxkbbwpFZoehlL0zP/lk4MIL\nre933+1fH5O6dcPvG0RYT8lzzwFTp/Igeeutdrfmzp32VYZLS3lA1MJIGyPhsH6GvvwydQvaK68A\nM2dyB+w2UJqeCK+OVVuPglynQHxWorDZLZwDUSKTZN0EpiBl1gw7q1WLvVhAuDaaJOKJcgoOYRRX\nL8NGOrJmFRezwBc0mfaHH3ii3aOPWm3QQmEmLKXt29u/J6tAO8+tm4e6qIjDwe66i4VspXjcrFaN\nxwW3Z8rrmu3ZY7/mzrl65v8++ojHF7eVyd08sbfcwp6Sp54Cnn7a29u+fDn3BbfdlvjCTW7CUljP\nudu9XloafQhcGOHc+ewEhWa+8YalgL30Eme0Mcezsly41anAJqIMOMNCU51EPGOG9TzMmcNjoYmp\n/Dp/c9IsllMzN5fHsNtus0Ir8/Is46LzWppzYYHEDC6JeP0rjTKghS5TEAjr4v3lF//4bafGv2OH\n+8MyfXq48sKgb5Jvv+X3t94Kjt386ivggQc4taMZS1lYyO9Dh3rXVQtw5v+inIC8cCFbOd57L7pl\nt836jRrF7wcOsGDuJVgEWX3M/zk7dWenZHaepnXdFDy+/95ez5o1eWJox47+9XDDnKOQKk4LnlsH\ns2ULD7RmiJNpoXOey5tvtgv6ZqeuPSCvvsrP00MPsaJRVBR+Um5xMQtmplBsWkE1ZmiQ232wdq39\nf4muvRHUGS9eHG8xByzl3I09e6x2eQles2fz+fJ6LnV/V1DA73q/IOW7ZUseiDp14u9O9/myZeHn\nSYWZB+OVtcipbCdCaSnX+4UX7N62O+/kTFDaC+aFKXwvXWqPKX7uufgwv0WLrH5m377UvdDOheL0\ns6O9Pdu2hROKnIqL8/lwGqy0tXLXLu7Piov5PgPsyryXkuem2Jv3iinA+3m2vIT4F16w5jCYdTfn\nRcyfb53/oJAmJ16eE7fn14nbNX/qKfYoRZnkYd264PVD3GSdWbPc9925Mz6xgs7Ao7nrrvD1Ky3l\nPiaqSAxnHP306eENiE6DydKl9nqZ416Y+jrvWeckeDM0ztlHzJnD/bXuS3TfuH9/vNJy4IAl35n3\neWkpbzfDPhMxTiRyTSJRBojoN0S0nIhWEtF1HvvcT0SriOhLIuob9thhbwL9MOTmAr//fdijM/fd\n55/ZxS0jSZhBLxWXudt/g2LcXn6ZFYEHHrAPiNpCaHZ8ztRdbp3iHXfEKyAbNyY3KfO11+zfo5iU\nZlo/TAFw82ZvZcDP+ugcbJ0xsM7z7xYLv327fQD++GP3gfS3vw1XJ1PwO/RQoHnz4LhCzfffc7ia\n273avHn8vhqleHBwEwDNcKCguQBNmlifnaFImzdbSkDYhaf+9794K5l5H+3Zw4qYeT5//pk78Fmz\nrO1Or0iQ9UR7k7TC+dln7pbbf/+bO/9p07znnLhZ6VesYKH1hRfsg4dm4ED7dy9lWhsOtCUprCdp\n3z6+lscfz9+1V237dvYGPf88W8zD9GdBazv4patMNL3ozz9bz8cdd/D5X7rU7m0zPaB+3k5TmPrl\nl/h7f+pUPm5JCT8fr7zC1/i229gDPXky/1ZcnPg8A7c0iro//uADvi/+8Y94heatt1ix1uXt2uUu\nhJrXzctgtXs3K4ROL6bGK6Wu28T4Rx9lJWPXLu/wSG1MKy11V+g1ppJgGll69rSeR+f585vg/+67\n9tBALyUkTPigmyVYC+1hMgF99124Cd5AcIigm8fbK748rKDvl97zwAGrzDlzuE+KIjJi8+b48XLb\nNj5+GG+ZDnGrVcvaZiY2MJWBffv43vPq15RyD+P1GnvN8PHlyy355PHH7efLjZYtrXvHNIrs3s3P\nSIMG1rbnn/c+Tti6upGyMkBEWQAeBHAMgB4AJhBRV8c+owF0UEp1AnAxgNAR9WGtyKYyULcun9zs\nbP+ToZS/JWHPHu/Z3s5OxE1bC5N1ZOlS4P777Qs1AXZBSjNtGgs2GzbE38DOdpo3lJvQ5gx18Fry\n2xTUlGLhUtdDhxM56w6wEldUxOfFTaGbMyc4A08QptBnhof5xY/6Cd5uHbgWpM269e/P70TA+PH8\nuXt3fne7n0wBWocDmOdfW+LccAqVu3dzXYLc4XPncie0caP78Z2Di9lRzZ3LbuMgwc7PUqljoHv1\n4veNG/1Dk/wEqB9+4AHMbYCeP5/vowMHOMTrjTfirUNTpvDAePfdfD2dwoefB0wp98nf//iH9fmn\nn/he91LWL73UXl8nTgHOzGpy/fWW0KPZutU9DEDHP+t79bTTrN/8smfs3ct9hL5m2kq9dKm9D3Nm\nC0rGEujMljNhgnWP1K8f/ji7drHR4/HH3SfweSkWXs+/ef8vXRpvqQe4HFMBcXLLLWxUuv32xDKA\nuT3Lun8wBWBT2FKK2/i//3F5c+bY9z3mGOtzmOQFrVvHTzbOywNGj+bPbn28n0Fn9WpWsr08sXqS\n/xtvcMhfomRne5/jW291375rF/dtWiH383aZaX3dCCvEu1FczP3FE09w+JNprDGfKVMGcKZrduIl\naJoRDPv3cyrUsPh5R269lZXg11+3+ttEwxHd0AYNN8IYEPWYdOKJ1jbzuTDvmY8+4nvvllu4P929\nm/tiPTZ6eWO8lIdly6zr5zRwPfCAf73r1wf6upjItTJSp449W+bWUEv22sfooNDvKDwDAwCsUkqt\nV0oVA3gOwBjHPmMATAWA2BoD9cxViYMI4x7VD4OefLJ1q5XVxevELV7sL1TdeSfw979b34cMAY44\ngj87BVy3uL6g+PSXXmJBcetWS2AsLuab0csSMGUKW15uucWutfqdI7cY59JSvmE/+YQfaq/JT/qB\nWLDA7t43Y+sfeCD+fGhh5dln3RW6efPYmqcf/hkzWMAKEjC2buWb2hTojjrK7tmYPZutCNnZ3KHm\n51u/mRZpk23bLI27Zk37dsB+fs0QH21hX7o0+D4tLHTv1P0sY84OSd+vQWEPpjJoWu927GDB3Bl/\na96rXu5lJ37XSndchx5qbfNb/dovxdozz/jHsH74ISvUQRm89u51zz39+ecsnGjldvlyqz6mgti5\ns3udg2KMmza1fzcHtSAPY40arKibVlqAhb+g2PtGjaxtjz/Oz6HzPCvF9ale3X5v/vpr/EQ+p+XP\nVGzMgcrvWjpDsrp0AY480irzu+/4mXvwQVZI165la56zrfq5/Okn93k3b73l/jx6CadOwVBbRU0j\nA8DhbX4x3Pra3nor1/njj90FaROn11QfZ86c+POl6+kUjN5/327Q6dPH+uzlpTIZNcquKDVtyvdE\nv37e/wky1PkpRPo5dN5TpsfUj/79gwVkJ07vhmmBvuwy+2/vvedf/6efDi5v3jxWPt57z37/Oi3f\n995r/a7L7NjRXqcg44++xmZol/N/t98ef9+ccw7QuLH13RxHzaxGJqaxZcECd1ll2bLE507s3etd\nJmDd3+vWBSv1Xl5rr3FkzhxWBFas4DU2ALsn4uqrLU+rn0FRK97NHNJtkFeDyK7AaExl4LzzrO33\n38/v8+ez982tr/vqq8TS4EehDLQCYIos38e2+e3zg8s+nnz0UbCbWluG9E1gWm+8Bmun5qsv5JIl\n8fmLu3bl9E9auAkTJnTPPd4XY9Uqu/Vp0yY+5m23WTdjEKaVLaymqAXjbdtY6Pnf/4KVlqKi4Ik4\nTstjWFf588+zRXP+fO64/vY3VjT0zb15MwsFTz/NddbWT9OaNHgwv0+caG3bupUtXZddBpx1lrV9\n5kxWgpzx26al17x3dKdvDspm+IUOwQKCLXB+Wai8sgTo8CczOwwQ74lSyl84X72az+/dd/OzpNHz\nSBKZ1K3L8SvvlFP43VTE/PAK05s1y1247NnT+rx2rftgaSp1Gq+Jdeak2eeeYyPAzp12ZcC81kC4\nTA3XXhu/zRwY/Casm8JAnz7xlh0vhVBfF+eA+OOP9vt+717rPvrxR7vRYOtW9+v74ovu5WvPGBB+\n5dtxsXXozfP6xBMsEPz0E4eqTZnCYZyPPMJ91Ztv8kAYxmNsPtMaN4X0xx+914E46SS7hwUIjt/W\nTJ7M4XEPPOCdZUd7tQDg8MOt7dOnu9+rW7bwPekW6mEqb05FTo91devGK5f167NgbVpltaCdm8sh\nF6bAqDHv4+uvB044wf57aWm8IqzxGss7deJEF27lmWjPvxduApvpmZw61S5A1avH97+pQCeywKBb\n3/7mm2yU+eADK9X0nj3uSoaur5YX9DOhvYJh59MMHgxcfLHVr+tx2Kuvzs8HLr/c+j5oULzRw0Sn\nkvaiqIj7zeefD041ax5z6VJW1vzkqlWrWBl/+mlvr7WpDJgGCoDPu9+8TvO5/uUXe4hb/frWGKP7\nTDclaM0aViqSmURuKvNaCdD9Rr16QMOG9v1LStiI+tVXlkFh+XLLa2XW/4orQpSfeJUzz6xZ/JD4\nWSz9UjR6WWydruCpU7nDeOml+FjHHj34vXZt7jScwtghh7iXYQpeJm6ChJvVsm5doHdv92Ns3Wpp\n+uYg7ccZZ/j/fsMNwF/+Eu5YJs5zHFYZ2LWLJ/iZ/1u71rLgPfQQCwXr1vHg7jzv1atbg4LTiqfd\n3tnZ8XHXftkW/vQnaxBTijtwc/A1J/OYg64pHJ17bryr2Zmyzxz83Vyse/daA5L2QJiDuB5QlWIv\ni+6k3Tr+//zH8v645SHX82LcXLFmvCJgzRnx84Q45yQ4KSoCrnPMLnJe259+co97nTgROPVUS9j3\nUmSc1nQnF1zg//vs2XYlzWmJnD7dP8To5JOt2FWzreacGz8rk1uooCmwz59vXXNzYNLX101Y0ts+\n/pjvGa+JjlOnug+cejEg57UfOdL6/P77diPI+++7ZyjTcxOcSpabMrFpE9+/8+aFN3y4jQm7dsUL\nos4UsCbt2nHff8014cr04r773J/Lxx+3Ph99tLWqudf6ANOmeV8zM8Y7OxsYMMD6vnOnFV5Yu7bd\nc+AmgJnXb+9efhbN/ZzPZY0a8Wt6KBUs1OuQS5Phw1mgDcIcF086CbjySut70Ly2b76xP8+5ufyM\nmgr4Sy9Zn82U0s77+JJLwid3+Phj935TG9v0vagFTzP23ctTYd5Xubk8PulnSo/Dbv2MqQRopWPQ\nIA7dc7J/P3s0br7ZvQ4miUw+Bthz8sILwfMsZs2y5hx5GWJ0/1S9uv0e+vRTy1sXBmdWLBOd6t1N\nKfr4Y/92XHVVuPL1/avvOecYDNgNWIsWcdufe46VJacBzalIuBGFMvADANM51Tq2zbnPIQH7uDJ5\nMh183X57ked+WtDR1o3zz7f/7owj9ropvEIZdMeh5yHs329Zi5Xytxa99lq89d1tcp+bgHrxxZaV\n1Q0tBOiHZMgQ++96UqAmNzdeaDbRwnWY1KKmNcQpFKW6SnPYh9Y8r861BcxO122dBT24Oa9NzZr2\nh+fOO73LN7V5rcXn5LCgM3FivKBj0rKl9dnNUmYOvrptpqVNp+grKeE2LFvG1lMvK6dbKJjOPKPP\ngZu1eeBAYNIk6/srr/D973WNnEK4UwHVHpyaNe0pFZ991n7NvDx62uJz9dXuvwP8zHjNgwFY2Grd\n2vt3ID6+3024NhX48eOBP/yBFZWTTrILXKaXwlR+9SB9wQXubmInzoF66VK+/ma+dJ09zA19H5l1\nMNFrQ5iMGGH/vndvfPiKU3jVRpDiYu8sSrouftcpKq6/3vrsDBUKE9/v12eGxRlnXlJir0tOjnWu\nk0mwYApIRMBvfmN9z8uzjF9eISemB9UU4nXfZBosTMOcFspr1bKndJ4/3z8d7jffeIdzVKsWbFCo\nWdNSMvv2tffZboqs+TwClgCuz5MOyTMF8F9/ZcHwjjvYGOWmiDVvbp/vctRR3nX+8EP3MLMlS+xj\nqO4HTTnBy4Bl9sPaWKCfR539xmlJz8mxX+NBg/g81qzJx9AGrw0b+L66/Xb3lLCpopR/aJAfc+fG\nGx21AaB6dXtKTud6Eoko9zosWHu+cnP5nGjZy8tYC8QbVp1pQp3o66cjH8y5sM6ynP2qaRDWqxbP\nnl2EyZMJWVkECsiJHUU3/DmAjkTUlohyAYwH4AwqeR3ARAAgooEAflVKhXKkTJqkDr6GDy/C0qXx\nWs/GjVZHqwfCQw6xu0acWpwZ0uGMs3PDTVh78kmOBw2aTLRwIYe/mG5Y/bD6ZfwYNcrqmNq1c9/n\n6aftddOT8TRuN5+X1cVp+XSbRNWuHYc+TJwIjB1rbTfb5pWGzhxsgnj4YfdYWj+cgrc5oLqdZ62w\nmKEaWujVc0Oc6NAGE6d1S9ejenW2NhUUuP+vZ0+7d6CoyC6YmNYcLTCZXomNG/n6m53AJ5+EP2/H\nHWcf+DZvdh+8Cwvj553cfnu8MjBsGAvDzkHX6XY2BSs9AVsTJr+1tpj7ZTPyyyhVrRp7wADLEhtE\ns2buyoBe10Ifq04dvq5uk8GcE2R//dVSwurVsxQzwIqjd9KpU/zgc8st9snLpkdh0iTgxhut7+++\n6z4BXZ8H05qscabBffZZ+31i9gNOvIRap6XLT4FJlT/9ye7B81vnwlwDxInTs6fvP7/wPxOzn9m5\nk6+bRgu+buP12LHxClkYsrKs83rggNW3uK3BAtjb5wxLBKwwG6dl21T+/e4FJ1On+guCF1/sP2ch\nCPP5P3DA3fMOxCt6psL99tv2EC+n1VcbM8yxJ2wWL2e5d9xhfdbHM8MsP/rIfu43beKwYvMZ08fU\n3lJtAHKGPPkpLIBliHrmGfdsimF56SU2sLr1xevWeacZBtzvQZN33+VxSMuD5rnxM8IBfJ50Pxq0\nSrf+XRuhFi+O79fMvtvEOWbk5PjXzfTW7N9vGaR0/2UaEP3Q4+jw4UWYNElBKX75kbIyoJQqAXA5\ngHcAfA3gOaXUMiK6mIguiu3zJoC1RLQawKMALvU8YAAvvMDxvJs3swtl6lT7ar+mgGDG/5msX2/P\nqRv0YADuwviWLRwPanbyAwZ4W/KffNLS/vVD6td5mjeptq7m51uCjMYcVJwxmm43utOCrjFj7gG2\nVl54od21NWECC5Dt2/ON/cc/8vZvvrEeRjfL9O9/z4NNIgpBoqvtEcW7qk2cgs7zz1s5ks1jAN73\njtvA7/QsmAK2nhjk9j8ie9YPwO5+1wOlUxgzhb1168KlsXOjQwe78KGtCU68YnPN6zx8OAuwQZYP\nwH5utXtec8897u5cnQN/6NBwi37162c/T2Ynev31lnI1xkh10LSpe9gCwCEcfuVOnBhcLz24aaXb\njLnWz+nYsdzX6HkwToj8PYVu++fm2tvp5gJ3Ziwyycuzz3349lv7YKjvd6dHaPv2eIucxjlh87jj\n7N+PPJKfmSDvjZPjj7crGgMGcP1N78M339gNKHrMOPZY/ywyznty6FD2Ap16anz9g3Aq7Kefzu9u\nGZV69fK+H9wwY/f1ff/xx1aZTkXVnH/zl78AN93k7QlRyh7O17ix/b6PcmFEIr5vvQwzbpiCvOn9\n8kuT6TT0tW5tGV2C5g2YxoyRI1nQcy4g58WJJ8Z78jX6PDr7lJtvtsbZhx9mIducQK/vffN+MT3C\n9etz/2caodzQcsnOnd5Zhcz7xoslS1iJdAtjDpqE3bYtz0U6+2z//fQ4aRok/eaTaE45BfjrX4Hf\n/c7a9qc/xe/nVMTXrrVfl+rV3cNwdGi5DqHUY4vTGGs+a+bYaE6u1+ODm5EpiEsuCbdfJA5apdTb\nSqkuSqlOSqk7YtseVUo9ZuxzuVKqo1Kqj1IqBV2Teeghtso5J236TUDRoQ3mxNu8PG9Lie7gBw+2\nC3hmhhQnxx5r3QRuvPEGC49ac3PTElu14oHQtLBqa+ZZZ/HN51QINM7OIyjjwqGH8g04fny8h4SI\n69KgAQsy11wTPzHNLYuIW8yv7tw6dGAFokGDeEHYjzBCJmC3wDs7ETfrmhkDaQoe1asDF13kP5lK\n4zxvpvU+UfRCJT//bAn5TgUvTEen8etIw8QRmlZo58BlWtqCLDE33sgdmXOeAMCuaefq2Gbmjyuv\n5CwjRUUslJuY94W5vki9eiyoXH01p/Y891wO3TnjDPv5y8vjQbl/fx4UjjvOPUSOyF/YD5PZpHFj\nfmnh0+yHdGffqxdfs6DjucX1+mFaWN36SHMQMhXq4cP52TX7P8CerlbX1emxuOceb2HK2T4ieyjf\nsGH8LE+cGG+k0DjnfJx5JlvCzefcfDbNicA6thiwlHltLND7Oc/x6NEs6OnnoHt3Foiys/n+GT+e\nr+PRR/P5vPBC9/DEDz+MF7D0s+g8L9pjE3bVa/NYgGXNN721ur26LHO+R3Z2vAHJNFjt3m238jqV\nOsDd2GQew2tS8UUXuW8fPtx+Ht1C2TSmp88MZfJbS8QtTCyscmeOh4MHs6Addqzq0MHb42MK804D\nRZhUrKYhxPSE/for99VB91PQopj6HjfxC/dbudJSpnftYgUljEX+9NPZOGIq+M666bV89HkxPVxB\nIYhZWfb7NS/Pfn8WFVntNJU88/nt0sU9ukQr5YMHs9Kh79sGDaz7JifH7g0wMa+bPlc1asT3KU5P\nvMlFFwWH22kqxARiL9wGGqe2alqib7893i119tneD0bjxmwpcT6wQZ6E7GwWfv7wh/jffvjBnhnA\nKVwD1kDo/M2cLFu9uvvxAXt4lJdQccEFPLidcALv72dRB/gB9LIWaWXK9LYAbN0bMSLeslO7Nnsb\nDj+c34M6z7ZtWRHp2ZMHBrPdTsWLiC11hx4an8kmN5cVEa9BxznPpGVLu0DgDGnROJVDv8HKDaeA\nC9jzEjvjIhNZKr5du/h5I07cJoxfcgmHmJhWaLd6aoKyEeXmsjDuluEHAA47zP7dnADozAphoq9l\n//72Tl0/J/Xrc+derRorI27KXUEBD/5mP+C07rlN5jXxq6PJjh08GDonwSai4AHhlFQnXkkOnJiC\nm6kAeim5uu5E4bNHueHWr+bm8rW49lrLu5GXx0pl69Y8WP/1r/yuhQTzWphZjkyFVQu0zhVFAe5T\nJk2KDyFr0oQVkxEj+HenMt21Kxtphg7lPrVVK/a4nHSStc/nn8cnwvCb+2LG/Tv7rQsvZCVXexWc\nbQPcw7S0sHT55awcB82HMM/Dm2/ak2u4jZ3OUKtatSzPHmC3xGr69/cOgcjKsissbqFsJm79lJnq\n0emNd/P6B60z4Id5Trzqat7rzvHikEPsgrZzcvKiRe7rYIQhEa+iH9nZ8d4FL3lE8+qrnF3r//6P\nBV2/5AlO48NFF7Gscv31rPQ7r9m//mUpvKanx629TkWvRg1+hvR6MG4yGWBXXp8TCz8AACAASURB\nVExvfMeOrAyYctf119v7m6ws+32h5dS8vHilyLzX3co2++S6df2VqrBhRUAFUAauuooHvrCrCjtv\noqCHWgsnbi6v/Hy+6Z0dntfJN93kubnuFpKtW+2Wc7dZ4mHxEqJNV7OXMtC6dbwAlizaI7Bpkz3F\n6BFH8I3rpzw1aMCdiFfMHcChVVlZLOQPH27l3D3ySN7mpGdP7jjcBqratb3DpNz2N7d5WUuc//Pq\nTLzQaeC8cF7nMJOr+/e3BmW3eGxTsHAKoj16WCsdmxB5h7WlOmG8Zk1vi6FfZ1enDguCTmE+EUuq\nG6ecYj/vzvAN5yAfxssCWFZZnScasAtKYSHiHOFO/AQ7txCo6tXjw3uqVbMmZpr9h1cOeHMfL09U\nmzYswLdo4Z3RLCeHvTTnnhv/W61a7N34/e/5ZSqVTutf69bcd48da//N/I9WArwWigu6f7x+d7NE\nmq5950rcN93kv9ia+VvLlhxikJ/Pz2+rVlYoRVGRZU02xzw3L7VWbOvXD6dUms+f6VHxmtfiHNNO\nPNF+XtzOXZASqf/j1XebmG0uLmbjiekZcM6rc3tmiCyPlJ5cG3YNBID7j7POihf0R43iY5kGsv79\nvcNSAR6zTPlk9257piMv3MZ3v8muYdDPes2a8d7gWrW4bWayCZNFi4JXe9c4PU41a7LRTZfpF15t\nGr969oz3ILr1g927W+OPDsNKtF9u1Mga+4M85bpPcHuG3EKBzGfGfAbOPtsub7Ru7R+54ke5VwYa\nNODBo25deyiBF07Bxm+SIWAN+GZMLcDWC68O30s4cXYy2dks6HqF9DhvhNat+eU1WTgI3fGY5yCZ\nVUITxRSazFR5iQhkRx3FD65bPlw3gb9NG7aYJCP0uQ2+frF4F1/Mnhq/0A0dBxg2XtSJaQF04gzP\nCfI8nH8+C8emUHDppZaH64QT4i0GprXErw1ebtdEvSFu/O538W096qjw1zhVBcCkdm22nPboYV9B\nWOMXCuiHW9/hNrk8DG4ClF+6VLN/qluX79kbbvB3M5t4eT/M/obIPUHBmWfygH7xxf4CaEGBd9im\nrndQCFV2NitKzv64ZUtL8NOWVR2+mOjchETRczJMa2jjxu73g/ncOu/pFi24bW4Wv5Ej2UsSNqQ1\nLETuYRB+oSTmbw0a+Hu+GjYMNwn7hhvCGQUbNrTO28sv21NdusWEe9G+PY9H2lLbqRMLu/p59RrX\nARa6nRPOAfexncha6RlwT2oQlKLVbZ9UwlUB9zHxvPNYKdfPlpuxNYp+OOgZr13bO+Oh8zy0bs2e\n7h497MkUvNAKU5g+3in0X3ONeyiskzZt2CPvNkHeaUx08y6NHcv3YaNGbEzs3JkNBBdcEOzF9qLc\nKwMmRxzBWrqXdmu6YzVeN+Z55/HN5EzFBbAl1bmCnPOYzhPesKG7oFSnDiskbp2YVlS08DVmDF/M\noFg6k6uv5oHmwgvtN40eLJyeknQQheuxdm0W+hs1sod2de2a/M3th3O+gl+e6BYtggerFi34fvKK\nbw7Cr+Nxs9w7KSjgAbioyD0cpGlTFrSLitwFBD3htk0bfy+Nm0B4xBHJK7AmRPEheUEhAc7/R0n1\n6hw/7uaxqFbNEnoTuT/dQtQSDREy0RP4NX6DqHl+rrkmOWHBbQB29ntu90ii3rJ0YXodSks57AVI\nbJJqMriFYXqF3Z11FlvTw+YkN3FeC+e9lewz4uat8TM0maEa5gRuN0Xv/PPDpZd1rpLth66bM5RY\ne4fCzrlp1Cj+nHXrxs9BkKFRc801PL4ccoi397NjRw4tOe8898nifn2yxnmNzHPau7d/OJobJ51k\nD7O78kqWK8aMsa6DNtQ5Q1HDpEn2I6wM5FTuvGSR5s25Lw/TDx12GJ8rNyOJ0/PpXGivZk3vUFgn\nXv2+8x53Cxvq1cuSSWrWZIO5lvmSTdWc4ILeZUtWFgu+O3e6LyriJ/g7F5ZxG8AvvZTDXMI8eJdd\nxh2OnoMQtMKbW5YFXYcJE3hiTzJCb/367pPUzjmH3YlhY5lTwa0Mv+wkQXTowIPzsmXRxTg6MePw\nL7wwtXCtKKhTh4WDWrXsqz17ucXPP5/zTu/cyZ/DDkxe5OS4TwZ04mYhDFrBOlGuusrKeBPkbjWJ\nWhnwIyuLB5iJE8NP0ALcLXyp1Lt2bR5UtPAVJCxdeSWvEZBKmddcY1/d1znA1qnDnoD33+eMSYmk\nm0w35v1kznHyWzwuCpz9y6mnehsYatQINwYlg2mBTgSvkEsvTGVAT1g1w0e6dbPWRUjkGQ/LqFHx\nIVmA1Q5tMMnEGhf16nEUgFdYlaZGDe8053Xrstfnww/j1xvo35+t307Dn/lcJjuOak+aV8acBg34\nujrvj4ICVkBycniC9q23hi+zVavw/VNeHgvBes5amDCyIIi8Q/ecRq9kPcRB5ZskYhwGLG9N2JTH\nmpSUASJqAOB5AG0BrANwulJqm8t+6wBsA1AKoFgplYC9Lx5T88rP5xtu9WpvS5fbA+bWATVt6q25\nu0HED3j9+uHTHep0mU2bWh6BatWit37n5mbWGldYaF+kKSh1WRBHHRUu5Wuy9O/P6eaGD09tsliU\nDB0aP+HPTOlocsghyXshUoEofqCNWghv0IAt6Mkcd+TIzCh2WohINCzM2SYzw02yaMGrsDB44Ag7\nt8GPevX4mfnhB7Z4u3kfO3YMzkhSFphKszl5ONnwvrAQ8X2pc9aHScuYDhLxtPnRrp3/XAcz57tW\nUM17f+xYzpGvVGqeMS8GDYpXBswEEXl53H/6xeqXN7Ky7M9vx47sRfDyynbuzONc2DBAN7p04cw/\nfuO5Vz+tr3tOjqUUhMFvrQ83jjvOWhAtTDhVReD00znZRFBiFzdatWLDXqLjYKqegesBvKuU+jsR\nXQfghtg2J6UAhiulfnH5LWGys1kJWLeOH+Zjj+V1B/wE+QsuYOt7vXp8kqMSYMIuQw7wTauVgXPO\nyawlM9107WopA86Z8+URPRiUN0wldfjw8nkeBw1ioUJbe5yLEEVBIlkQTBLJx54KUQkwyWQFcnLW\nWZzq0y/bU9Sccw73o1EoF5mEiJ9958KVmfCgDh3KXj8z9CITtGiR+gR/gD22a9bEZ0px44QTuK3O\nyemanByOrc7EnDaNM/Q33QpgOujalcNY+vcPFnyzshJf/8JJfj6H4oQNffGrSxiSUVxateKJ+Lt2\n+SuoFYlU+4hkjMupKgNjAGhxeAqA2XBXBggRz0844wxe9Kh3bx6Yg+Jf9eTcsiQnh+P6fvopGndW\necKcLBVmRWfBnXRYydJBTg5bWfftK58KS7pJpc2XXw48+GA4S34YOnRwn6yYTqpVq3iKgCaTAqiJ\nnhyd6fN21lnsBUk0bMDJmDEclhgmrKdZs2ALbzrCg/yI4lkra6pVSz7UK1mikFV697ZHDjgZMYJD\nd5ONBqhWLXOKQJs29gXOKgupKgNNlVKbAEAptZGIvGzzCsBMIioB8JhS6l8plovc3OhcnpmkbVv/\nbBkVFSJ2JX7ySfh85oI7EyYAM2a4ZxooTwwbxq74ZFyZFZ1UlIHGjb0zYQjpZ8+esiu7LMJS8vKi\niW2uWzfaFYbTjRYwGzbkRRyrotGivDB6NCujH37IER1OvFZiLo+MG8drJVQ2oyepADMJEc0EYDrY\nCCzc/xnA00qphsa+Pyul4ro7ImqhlNpARE0AzARwuVJqbmDliGyVmzRpEopkFC23HDjAk8J69MjM\nxCyhbCktZcEqExmrygtffcVWVq91LITyz7x5VhYhjQwrgpAZNm0CHn6YP59zDofoVbRY/+Ji9o6X\n9zGgqKgIkx0r7SqlXGsdqAz4QUTLwHMBNhFRcwDvK6V8nZFENAnADqXUPSGOr1KpnyAIgiCYLFkS\nv2iTKAOCkBm2brUWXZTnLrMQkacykKr99nUA58Q+nw3gNZfC84ioduxzLQCjACS5mLYgCIIgJE8U\nk7YFQUgOPRk5E5P2hfCk6hloCOAFAIcAWA9OLforEbUA8C+l1PFE1A7AK+DQohwAzyil7gh5fPEM\nCIIgCJGyZo19nQGxUApC5ti0ieefpJqlSEgMP89AShOIlVJbAYxw2b4BwPGxz2sBuCxsLQiCIAiZ\np7i4rGsgCFUXZ5rXIEpKSrBmzZr0VKaS0qFDB2QnkJ5QpnkKgiAIVYqwCyAJglD2rFmzBmvNVQIF\nX9auXZuw8pRqalFBEARBqFCUl1XHBUEIR7t27dBZJvykDfEMCIIgCFWKBg145XoAaN68bOsiCIJQ\n1ohnQBAEQahyFBbyWhm9e5d1TQRBEMoW8QwIgiAIVY6sLGDgQF6hVxAEIYjs7GwUFBSgd+/eGDt2\nLHbt2pXUcS666CIsX748bvuUKVNwxRVXpFrNpEhJGSCiU4loCRGVEFGBz36/IaLlRLSSiK5LpUxB\nEARBEARByCS1atXCggULsHjxYtSpUwePPvpoUsd57LHH0LVrV9ffqIyWNU7VM/AVgJMBzPHagYiy\nADwI4BgAPQBMICL3syAIgiAIgiAI5ZjDDz/clrHnrrvuwoABA9C3b19MnjwZALB7924cf/zx6Nev\nH3r37o0XX3wRAHDkkUdiwYIFAICnnnoKXbp0wcCBA/HRRx8dPN65556LadOmHfxep04d37JSJdV1\nBlYAAPmrMgMArFJKrY/t+xyAMQDifSSCIAiCIAiC4MGTTwLbt0d7zLp1gfPO899HL4JbUlKCmTNn\n4qijjgIAzJw5E6tWrcK8efOglMKJJ56IuXPnYvPmzWjVqhVmzJgBANixY4fteBs3bkRRUREWLlyI\nunXrYvjw4SgocA+y0WK2V1lDhgxJpfkZmTPQCsB3xvfvY9sEQRAEQRAEodyzZ88eFBQUoEWLFvju\nu+9wySWXAADeeecdzJw5EwUFBSgoKMCKFSuwatUq9OrVCzNnzsQNN9yAuXPn2qz7APDZZ5/hyCOP\nRMOGDZGTk4Nx48YF1sGrrFQJ9AwQ0UwA5npxBEABuEkpNT3lGgSXf/DzpEmTUCTrxguCIAiCIFRJ\ngiz46SIvLw8LFizA3r17ccwxx+D111/HSSedBKUUbrjhBlx44YVx/1mwYAHefPNN/PnPf8aIESPw\n5z//2fa79jY4ycnJQWlp6cF99u/ff/CzV1lOioqKQocRBXoGlFIjlVK9jVev2HtYReAHAG2M761j\n20KhlDr4EkVAEARBEARByDRacK9Rowbuu+8+3HjjjQCAY445Bk8++eTB7EI//vgjtmzZgg0bNqBm\nzZo444wzcO211x6cJ6A57LDD8MEHH+CXX35BcXHxwTkFAJCfn4/58+cDAF577TUUFxf7luVGUVGR\nTYb2I8p1BrzmDXwOoCMRtQWwAcB4ABMiLFcQBEEQBEEQ0oYZqdK3b1906tQJzz//PMaNG4dly5bh\n8MMPB8CTff/zn/9g1apVuPbaa5GVlYXc3Fw88sgjtuM0b94cRUVFGDhwIBo0aIC+ffsePP6FF16I\nMWPGoF+/fjjmmGNQq1YtAMDIkSOxfPnyuLKaNGmSWtuCtAXfPxOdBOABAI0B/ArgS6XUaCJqAeBf\nSqnjY/v9BsB9YE/EE0qpO0IeX6VSP0EQBEEQBKHisnLlSgBA586dy7gmFQOv80VEUEq5Gu5TzSb0\nKoBXXbZvAHC88f1tAF1SKUsQBEEQBEEQhGiRFYgFQRAEQRAEoYoiyoAgCIIgCIIgVFFEGRAEQRAE\nQRCEKkqU2YQEQRAEQRAEIVLWrl1b1lWoMKxduxbt2rVL6D+pZhM6FUARgG4A+iulFnjstw7ANgCl\nAIqVUgNCHl+yCQmCIAiCIFRRSkpKsGbNmrKuRoWiQ4cOyM7Otm3zyyZkW5Ag0Rc4Q1AnAO8BKPDZ\n7xsADZI4vqpqTJo0qayrkFYqe/vcqGptrmrt1VSldleltppIuys/VamtJlWp3VWprSYxmdpV3k7J\nM2BoG+8D+IPy9gysBVColPo5weOqKOpXkYhpbmVdjbRR2dvnRlVrc1Vrr6YqtbsqtdVE2l35qUpt\nNalK7a5KbTXx8wxkagKxAjCTiD4nogszVKYgCIIgCIIgCD4ETiAmopkAmpmbwML9TUqp6SHLGayU\n2kBETcBKwTKl1NzEqysIgiAIgiAIQlQEKgNKqZGpFqJ4RWIopbYQ0SsABgAIpQwQuc91qMxU9jZX\n9va5UdXaXNXaq6lK7a5KbTWRdld+qlJbTapSu6tSW8MQZWpR1zNLRHkAspRSO4moFoBRACaHOaBX\nbJMgCIIgCIIgCKmT0pwBIjqJiL4DMBDADCJ6K7a9BRHNiO3WDMBcIloI4FMA05VS76RSriAIgiAI\ngiAIqRNJNiFBEARBEARBECoemcomJAiCIAiCIAhCOUOUAUEQBEEQBEGooogyIAiCIAiCIAhVlMiU\nASLaEcExhhLRF0RUTESnOH67k4i+IqLFRHS6sf2o2H8WE9FTRJQV296IiN4ioi9j/zsn1fo56lNC\nRAuIaGHsvY3PvsOIKHBNBiK6jIhWxY7d0Nhen4imEdEiIvqUiLobv10Va99XRHSlsb0/Ec2L1W8e\nERUm0LZSIppqfM8moi1E9HrYY3gc9wki2kREix3bexPRx7H2vUZEtWPbqxHRk7Fru5CIhhn/OTfW\n5i+J6E3zfKVKbGJ8KRF1juBYpxLRktg1LTC2+7VtXOxcfEVEfzO2dyCiD2L7f0lEo5OsU1qub+xY\nDYnoPSLaQUT3O37zalcbIno39tt7RNTS+O0+Ivo69ro31foZx42iv6oQbTWO79tmInrfvEeN7eWi\nX0qEKJ9h45jl+noT0U2xvmYR8ZjUP4Jjlts2E1ErInqViFbG7s9/EJFvhsTYfVnD47dyf5/H7un/\nM77/gYj+GsFxy53sRZaMtSR2Hn9PlHo+0PLY1nKBUiqSF4DtERyjDYCeAJ4GcIqx/VgA/wOnL80D\nMA9A7dj3bwF0iO1XBODc2OdJAP4W+9wYwM8AcsqivQCGAXg9xH59YufgGwANje1/B/CX2OcuAN6N\nfe4BYDGA6gCyAcwE0D722/sARsU+jwbwfgL13QFgAYDqse+/iX0PbINxjGyXbUMA9AWw2LF9HoAh\nsc/nALg59vlSAE/EPjcBMD/2uVrsejaIfb8TwF8jvLbPAXgdwKQk/pvl+N4FQCcA7wEoMLZ7ta0h\ngPX6+gN4CsCRxueLY5+7AVibZPtSvr4+x84DMAjARQDuN7b7tesFAGfGPg8HMNV4bj6MfSYAHwM4\nIqJrHEV/VSHaGrbN4D6jwGV7ueiXEmxr0s9wRbze4Ix+HyE2xsXq1LySt/kzABON4z0O4O8B/1lr\n3sMV7T4HsAfAGuO8/wERjH0oh7IXjP4qdpyZAIoqY1vLwyvSMCEiyotZBObHtOgTY9vbEtFSInos\npuW9TUTVnf9XSn2rlFoCXuHYpDuADxSzG/wA/gZAIwD7lFJrYvu9C2Bs7PNGAHVin+sA+FkpdSDK\n5sZtIMoior8T0WcxTfFC4+d6RDSDiJYT0UNuB1RKLVJKfety7O5gYRJKqRUA8olXc+4G4DOl1D6l\nVAmAOQC0prsBQL3Y5/oAfkiwfW8COC72eQKA/xrt7E9syf+CiOYSUafY9rOJLfuzwNfC2b65AH5x\nKauTslakftdog9nuLQB+jVlYDgDYCqBOzFJQF8CPCbbPFeK1MA4DcBmA8cb2YUQ0x+0axqxmdxGn\nzx1oHk8ptUIptQr+19RsW3sAK5VSW2P7zYJ1T2+ItRVI7pqaJHN95xBRb2O/D4mol6O9u5VSHwPY\n5yjPr13dwYMnlFKzAYyJbd8MIDdmyasJXhdlUwptNiFyeOyI6AEimhj7vJaIimLnYBG5WJgrUFs1\nvm32opz1S4EEPMNe1/tYIlpGRJ8TW6/jPLnl/Hq3APCTHuOUUluVUhtjbSsgotmxtr1FRM1i298n\nontjVtfF5OJJKK9tJqKjAOxRSk2NlaMAXAPgPCKqERuL/48s7/H/t3fuwVZWVQD/LR7jgAmi6B88\nxVAhjQREKMeQkGSijCRSyscAY04KNdUYlf3TAzJNjO5QPnhMY2AZ1WQ6qHeAhEiJgHsDuoDpVewx\nI86ED8IH19Ufa32cfc8959zznXPifNe7fzMOx72/b++9vr2//a291tr73iIiC4FBwCb/RuXL2hXG\n+THgPuAr+RmuZ21weRtFZIiI9BOR54Nr+orIQRHpGd6bdd1LVV/GFqQLXI6iupaILJKcx31JgbIy\nLWu9qPWegTeAmap6EfAR4K4gbyTQoKoXAK+Qe5jl0AxMF5E+IjIQmAIM9QHSS3Ku7U8DQ/33/cD5\nIvIvv/9LlQpVhD6SCxP6tafNBw6r6kTsryx/XkSGe94E7OM0Ghgpee6pTmjGJxkRuRhb2Q4B9gCX\nisgAsT/u9jFy8n8dWCoiBzHLxjdS1KeYZW2OL9rGYFaYhBbMkj8eXxkHeWOx1faUFPXtFV84Ap8J\nZGgGrhQLYxkBjMf6XbH+3AP8A3umK1PUV4pPAo+r6ovASyIyNsgr1ocnA0+p6lj/cJZDQdmAvwPn\nibnaewEzyT2P7wM3iP1tj0eAhRXKWGn/rgDmAvgC4SRV3V1mnaXkaiI3vq8C3iMiA1S1BXgC+7D+\nE+uX/ZUIXASl4wch5CV/BvcAt6YoN4uyJnQmcxpO9LxULqXe4Q6y+ztwD3CFqk7APHVpnlEW+vsJ\nYJiYoWK5iHzY6+wFNACzXLbVQKgg9VHVsdi8tipFffWW+XxgR5igqq9h3oqRmOI4HBijqhcCa1S1\nweu9TFWnpqgrS+NcgeXA50TklLy8BmC1y7sW07deBcIw1I8Dj/nipRwyo3upaivQwxdiBXUtEZkO\nfAKY4OP6jhRVZEbWelDrxYAAt4tIM7Z6GiQiZ3pea6A47ADOKrdQVW0E1mNuxTX+bzKYrwF+JCJP\nA68G6d8EmlV1EKagLhePRa8R/1XVca4AJgubjwLXi1mIt2Gu1HM878+q+oIrsg9iITPlcjswQER2\nYpP2LqBNVfdhITKNmKV3Fzn5VwILVXUYZjFJM9HjK+ezMKvxo7S3lpwKrBOR3cDd2Io6oVFVX0lT\nFzAPuEVEtmOK9VuevgqbvLcDSzE3eJtPgg3YRD8Y2I31dy2Yg7m5AX4FfDbIK9aHbcBvUtZTUDZV\nPQx8wdvwJObWTvp0KbBCVYdiVv2fp6zzOBX27zpghluV5mFu1nLrKyXXrcBlIrIDuBR7Lm2u0EzB\nrHmDgakicklaWavgt/7vDkyxKIsuKmslnPB5qUxKvcOFGAU861ZhCLxk5ZCF/lbVI8A4TAk+BPxC\nzOtxHhYS0ejfpdu8zoQH/f4tmKe1H2WQBZmLkMxjlwP3+lydtDfJTxt3nqlxrqqvAz+jo+L5QXJj\n9wEgebYPAVf772uAX6aoK4u6FxTXtS7HFkRvevsPFy+iPRmW9YRQcrNNSgS4FnOpjFXVd0SkFUg2\n64RuxrYgvSxUdQlu0RCRNcABT98GJFaQaUDizv8QsNivedbbMgr4S2rJykewCaCxXaKtyvMtTaUs\nT+3y3OIxLyivFYtrRFVXY9YeRGQx8KJfNlFVp/k160SkEsv5w8CdWNznwCD9u8BGVb3KPR+bgrwj\naStR1QPAFXDc4jzD09sI3KEishXr99HAc6r6vGc9BCxKW28+IjIA82hdICKKxYEqOatwsT48mnx0\nyqWEbKjqo5iCjrs/k4nnEixeEVV9WswdPtAtF5WQqn9V9aiINGJWwNmYN6Nsismlqv/GPYViIR6z\nVPVVEZkErFfVo563Hvvgba1I2o4cw/o4IX9OSuasNlLOlRmUNaEzmUuRlXmpKJ28w8dobwALZa9q\nY2IW+tvnoM3AZl/IX4/tBdqjqsWU7rBPhdLfpfz66inz3zALba7xtpBJvKvVkPlxDizD+nZ1sXYH\nPAws9ndjHB7yVC5Z0b1E5GxsEXZIRIrpWtOrqSMrstaDWnsG+mGu9XdEZArtrWlpJ9vj14vFh53m\nv8cA78fcjbjLKHH1LgJ+6rftw1aJiMVInou/wDWikDyPAze72xQROUdE+njeRHdj9cBW6X8scH9Y\ndih/fxHp7b9vBJ5060Ao/zDgU5h7EOCZxDUoIlPxQZ1StlXAt1V1b15+f3IxkHNTlJuU3e7ZBTL0\nAL6Fuexxd11f/z0NeNutMc8Bo0TkdC9iGhbaUi2zsc1uI1T1bFUdDrSKSOIBuDivD7cEMpVD2KfF\nZAufxwBso/H9flsLuTE9GgvTqWQhUE3/rgR+jHlJOvMAFevnRK4V/v+n++QO5k5PrGj7gMlioVS9\nsQ2ItehnsA/nC8D7xE52OhVIEzqQT5ZlTahW5nrPS+VQ6h0uJvt+YITkToS7umOxHchUf4vIuSIy\nMki6EJN3P3CGK+KISC8JTsPBZfXnc9gV36LV5NVZN5lVdQMWqnut19kT+CFmFX4Ds9bf5OlJG8Gs\nup15P7I8zgVAVf+DGcHmB3l/wrxiYIbZLX7tEUw5XQY8UobhKiu6V9iOM7z8Bk8qpGv1xfp9bqJ3\nBf2edVnrj9Zmh3tPzDV5GjYgmzGlYS8WXzec4AQZiuyABy7CVtaveXm7Pf0kL2uPlz8muOcOzErQ\ngq0Uk/SBwO+9LX8F5tRC1qD8DidzYANrsde3G9tUdQo26f3B29MCLC9S5kKX/y0sFv4+T5+ETeot\nWKhG/+Cezf5cdmGxkOGz3ObpT2Hemmpkm4yfNhO0ZwfwHcxKD3ADwYkTBcpYi230fRPbnZ/syP+i\nl7cPWBJcP9zT9mIv5dAg7zp/xk3A7/CThars0w34CRBB2gIsRnMy5g7v0IeFnleQN9P79CgWK7u+\nDNnWBuN9dpD+Xh9HTZhVaGoNx26n/Rtc2wJMK1F+K/Ay9uE9CIzqRK5Z2MdyH7Y5rneQd7dfvwe4\ns0bvbk/gkP/+gcv6GPZuJaeTHD9RBPOAbOyKsqaUud2JV8G9mZiXqniHwaL9fAAAAXJJREFUF+Lv\nawnZZ7gc24GfAA90pf7GLL5bvawmly0Zv2OwuasJmzPne/omLPRwJ/bNGt/FZB6MWb0PAM9gym7v\nYLzf5e3bBdzs6Qu8XRu64jin/Qk7ZwKvkzvpaJiP/yZMKR6S1ydt+Kl9BcrNnO4FvO1jM3m+Xw7y\nCupanvc1b/NO4HtdQdYs/CcuUFWIyAew+LxJnV4ciXRB3MrzVVW9stOL38WInRm+UVVH1bstldId\n56vuKHMaRORkNQsqIrIcOylnWZ2b9X9FRDZhc9rOerclEonUl6rDhETkJmyzxW3VNycSiWQVEbkO\ns3LVarP2Cac7zlfdUeYKuFHsZLi9WBjJvfVu0AmgektgJBJ5V1ATz0AkEolEIpFIJBLpetR6A3Ek\nEolEIpFIJBLpIsTFQCQSiUQikUgk0k2Ji4FIJBKJRCKRSKSbEhcDkUgkEolEIpFINyUuBiKRSCQS\niUQikW5KXAxEIpFIJBKJRCLdlP8B8fhKBhig/CYAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f55b2114650>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "%matplotlib inline\n",
-    "import matplotlib.pyplot as plt\n",
-    "from matplotlib import style\n",
-    "style.use('seaborn-notebook')\n",
-    "\n",
-    "\n",
-    "fig, (ax0, ax1, ax2) = plt.subplots(nrows=3, sharey=True, sharex=True, figsize=(13, 5))\n",
-    "\n",
-    "ax0.plot(obs.index, obs['anomaly'], label=u'Observations')\n",
-    "ax0.legend(numpoints=1, loc='lower right')\n",
-    "\n",
-    "ax1.plot(obs.index, tide['h'], alpha=0.5, label=u'Prediction')\n",
-    "ax1.legend(numpoints=1, loc='lower right')\n",
-    "\n",
-    "ax2.plot(obs.index, obs['anomaly']-tide['h'], alpha=0.5, label=u'Residue')\n",
-    "_ = ax2.legend(numpoints=1, loc='lower right')"
+    "tide = utide.reconstruct(time, coef)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output from the reconstruction is also a Bunch:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(tide.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#t = obs.index.values  # dtype is '<M8[ns]' (numpy datetime64)\n",
+    "# It is more efficient to supply the time directly as matplotlib\n",
+    "# datenum floats:\n",
+    "t = tide.t_mpl\n",
+    "\n",
+    "fig, (ax0, ax1, ax2) = plt.subplots(nrows=3, sharey=True, sharex=True)\n",
+    "\n",
+    "ax0.plot(t, obs.anomaly, label=u'Observations', color='C0')\n",
+    "ax1.plot(t, tide.h, label=u'Tide Fit', color='C1')\n",
+    "ax2.plot(t, obs.anomaly - tide.h, label=u'Residual', color='C2')\n",
+    "ax2.xaxis_date()\n",
+    "fig.legend(ncol=3, loc='upper center')\n",
+    "fig.autofmt_xdate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.8"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/utide/__init__.py
+++ b/utide/__init__.py
@@ -2,12 +2,15 @@ from __future__ import (absolute_import, division, print_function)
 
 from ._solve import solve
 from ._reconstruct import reconstruct
-from ._ut_constants import ut_constants, constit_index_dict
+from ._ut_constants import (ut_constants, constit_index_dict,
+                            hours_per_cycle, cycles_per_hour)
 
 __all__ = ['solve',
            'reconstruct',
            'ut_constants',
-           'constit_index_dict']
+           'constit_index_dict',
+           'hours_per_cycle',
+           'cycles_per_hour']
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/utide/_reconstruct.py
+++ b/utide/_reconstruct.py
@@ -48,13 +48,26 @@ def reconstruct(t, coef,
         Scalar time series is returned as `tide.h`; a vector
         series as `tide.u`, `tide.v`.  Each is an ndarray with
         ``np.nan`` as the missing value.
+        Most input kwargs are included: 'epoch', 'constit',
+        'min_SNR', and 'min_PE'.
+        The input time array is included as 't_in', and 't_mpl';
+        the former is the original input time argument, and the
+        latter is the time as a matplotlib datenum.  If 'epoch'
+        is 'python', these will be identical, and the names will
+        point to the same array.
 
     """
 
+    out = Bunch(t_in=t, epoch=epoch, constit=constit, min_SNR=min_SNR,
+                min_PE=min_PE)
     t = np.atleast_1d(t)
     if t.ndim != 1:
         raise ValueError("t must be a 1-D array")
     t = _normalize_time(t, epoch)
+    if epoch == 'python':
+        out.t_mpl = out.t_in
+    else:
+        out.t_mpl = t
     t = np.ma.masked_invalid(t)
     goodmask = ~np.ma.getmaskarray(t)
     t = t.compressed()
@@ -65,7 +78,6 @@ def reconstruct(t, coef,
                         min_SNR=min_SNR,
                         min_PE=min_PE)
 
-    out = Bunch()
     if v is not None:
         out.u, out.v = u, v
     else:

--- a/utide/_solve.py
+++ b/utide/_solve.py
@@ -116,22 +116,22 @@ def solve(t, u, v=None, lat=None, **opts):
         Sea-surface height, velocity component, etc.
     v : {None, array_like}, optional
         If `u` is a velocity component, `v` is the orthogonal component.
-    lat : float
-        Latitude in degrees; required.
+    lat : float, required
+        Latitude in degrees.
     epoch : {string, `datetime.date`, `datetime.datetime`}, optional
         Valid strings are 'python' (default); 'matlab' if `t` is
         an array of Matlab datenums; or an arbitrary date in the
         form 'YYYY-MM-DD'.  The default corresponds to the Python
         standard library `datetime` proleptic Gregorian calendar,
-        starting with 1 on January 1 of year 1.
+        starting with 1 at 00:00 on January 1 of year 1; this is
+        the 'datenum' used by Matplotlib.
     constit : {'auto', array_like}, optional
         List of strings with standard letter abbreviations of
         tidal constituents; or 'auto' to let the list be determined
         based on the time span.
     conf_int : {'linear', 'MC', 'none'}, optional
         If not 'none' (string), calculate linearized confidence
-        intervals, or use a Monte-Carlo simulation (not yet
-        implemented).
+        intervals, or use a Monte-Carlo simulation.
     method : {'ols', 'robust'}, optional
         Solve with ordinary least squares, or with a robust algorithm.
     trend : bool, optional

--- a/utide/_ut_constants.py
+++ b/utide/_ut_constants.py
@@ -1,8 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
 
 import os
+import numpy as np
 
-from .utilities import convert_unicode_arrays, loadbunch
+from .utilities import convert_unicode_arrays, loadbunch, Bunch
 
 
 _base_dir = os.path.join(os.path.dirname(__file__), 'data')
@@ -17,3 +18,8 @@ constit_names = list(ut_constants.const.name)
 # Make a dictionary for index lookups.
 constit_index_dict = dict([(name, i) for (i, name) in
                            enumerate(constit_names)])
+
+_uc = ut_constants.const
+cycles_per_hour = Bunch(zip(_uc.name, _uc.freq))
+with np.errstate(divide='ignore'):
+    hours_per_cycle = Bunch(zip(_uc.name, 1/_uc.freq))


### PR DESCRIPTION
The returned Bunch now includes the kwargs and the times,
with the latter both in the original form and in matplotlib
datenums.

Added two convenience Bunch objects to the utide namespace:
hours_per_cycle and cycles_per_hour, both indexed with the
constituent name.

Updated the utide_real_data_example.ipynb notebook, and
stored it without output.