### PR TITLE
call lstsq with rcond=None to use new default

### DIFF
--- a/utide/_solve.py
+++ b/utide/_solve.py
@@ -286,7 +286,7 @@ def _solv1(tin, uin, vin, lat, **opts):
         xraw = u
 
     if opt.newopts.method == 'ols':
-        m = np.linalg.lstsq(B, xraw)[0]  # Model coefficients.
+        m = np.linalg.lstsq(B, xraw, rcond=None)[0]  # Model coefficients.
         W = np.ones(nt)  # Uniform weighting; we could use a scalar 1, or None.
     else:
         rf = robustfit(B, xraw, **opt.newopts.robust_kw)

--- a/utide/_solve.py
+++ b/utide/_solve.py
@@ -286,7 +286,10 @@ def _solv1(tin, uin, vin, lat, **opts):
         xraw = u
 
     if opt.newopts.method == 'ols':
-        m = np.linalg.lstsq(B, xraw, rcond=None)[0]  # Model coefficients.
+        try:
+          m = np.linalg.lstsq(B, xraw, rcond=None)[0]  # Model coefficients.
+        except:
+          m = np.linalg.lstsq(B, xraw)[0]  # Model coefficients
         W = np.ones(nt)  # Uniform weighting; we could use a scalar 1, or None.
     else:
         rf = robustfit(B, xraw, **opt.newopts.robust_kw)


### PR DESCRIPTION
call `lstsq` with `rcond=None` to [use new default](https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.linalg.lstsq.html) and silence warning.