### PR TITLE
Silence some "invalid value" warnings.

### DIFF
--- a/utide/_reconstruct.py
+++ b/utide/_reconstruct.py
@@ -103,7 +103,8 @@ def _reconstruct(t, goodmask, coef, verbose, constit, min_SNR, min_PE):
             N = (coef['A_ci']/1.96)**2
         SNR = E / N
         PE = 100 * E / E.sum()
-        ind = np.logical_and(SNR >= min_SNR, PE >= min_PE)
+        with np.errstate(invalid='ignore'):
+            ind = np.logical_and(SNR >= min_SNR, PE >= min_PE)
 
     # Complex coefficients.
     rpd = np.pi/180

--- a/utide/confidence.py
+++ b/utide/confidence.py
@@ -238,7 +238,9 @@ def _confidence(coef, cnstit, opt, t, e, tin, elor, xraw, xmod, W, m, B,
                     varYv = Pvv[c] * varYv / den
                     varcov_mCc[c, :, :] = np.diag(np.array([varXu, varYu,
                                                             varXv, varYv]))
-                sig1, sig2 = ut_linci(Xu[c] + 1j * Xv[c], Yu[c] + 1j * Yv[c],
+                with np.errstate(invalid='ignore'):
+                    sig1, sig2 = ut_linci(Xu[c] + 1j * Xv[c],
+                                      Yu[c] + 1j * Yv[c],
                                       np.sqrt(varXu) + 1j * np.sqrt(varXv),
                                       np.sqrt(varYu) + 1j * np.sqrt(varYv))
                 coef['Lsmaj_ci'][c] = 1.96 * np.real(sig1)


### PR DESCRIPTION
Letting the nans propagate, or cause the corresponding boolean to
be False, is fine in these locations.