### PR TITLE
Do not try to calculate diagnostics when conf_int is 'none'.

### DIFF
--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -9,15 +9,18 @@ Smoke testing--just see if the system runs.
 
 from __future__ import (absolute_import, division, print_function)
 
+import pytest
+
 import numpy as np
 
 from utide import reconstruct
 from utide import solve
 from utide._ut_constants import ut_constants
 from utide.utilities import Bunch
-
-
-def test_roundtrip():
+# We omit the 'MC' case for now because with this test data, it
+# fails with 'numpy.linalg.LinAlgError: SVD did not converge'.
+@pytest.mark.parametrize('conf_int',  ['linear', 'none'])
+def test_roundtrip(conf_int):
     """Minimal conversion from simple_utide_test."""
     ts = 735604
     duration = 35
@@ -44,7 +47,7 @@ def test_roundtrip():
         'nodal': False,
         'trend': False,
         'method': 'ols',
-        'conf_int': 'linear',
+        'conf_int': conf_int,
         'Rayleigh_min': 0.95,
     }
 

--- a/utide/_reconstruct.py
+++ b/utide/_reconstruct.py
@@ -92,7 +92,7 @@ def _reconstruct(t, goodmask, coef, verbose, constit, min_SNR, min_PE):
     # Determine constituents to include.
     if constit is not None:
         ind = [i for i, c in enumerate(coef['name']) if c in constit]
-    elif min_SNR == 0 and min_PE == 0:
+    elif (min_SNR == 0 and min_PE == 0) or coef['aux']['opt']['nodiagn']:
         ind = slice(None)
     else:
         if twodim:

--- a/utide/_solve.py
+++ b/utide/_solve.py
@@ -57,6 +57,7 @@ def _translate_opts(opts):
         oldopts.linci = False
     elif opts.conf_int == 'none':
         oldopts.conf_int = False
+        oldopts.nodiagn = 1
     else:
         raise ValueError("'conf_int' must be 'linear', 'MC', or 'none'")
 


### PR DESCRIPTION
Closes #78.
The smoke-test has been extended to catch this.