### PR TITLE
Allow invalid in fmod without warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ var/
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
+pip-wheel-metadata/
 
 # Unit test / coverage reports
 htmlcov/
@@ -68,3 +69,4 @@ doc/_build/
 *.kdev4
 .project
 .pydevproject
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ env:
 matrix:
   fast_finish: true
   include:
+    - name: "python-3.9 numpy 1.20"
+      env: PY=3.9 NP=1.20
     - name: "python-3.8 numpy=1.17"
       env: PY=3.8 NP=1.17
-    - name: "python-3.8 numpy=1.14"
-      env: PY=3.8 NP=1.14
     - name: "python-3.7"
       env: PY=3.7
     - name: "coding_standards"

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,12 +38,6 @@ include_package_data = True
 [sdist]
 formats = gztar
 
-[tool:pytest]
-flake8-max-line-length = 105
-flake8-ignore =
-    E741,E226,W504
-    docs/* ALL
-
 [check-manifest]
 ignore =
     *.yml

--- a/utide/harmonics.py
+++ b/utide/harmonics.py
@@ -158,11 +158,6 @@ def FUV(t, tref, lind, lat, ngflgs):
         F = F[lind, :].T
         U = U[lind, :].T
 
-        # if ngflgs[0]:  # Nodal/satellite with linearized times.
-        #    F = F[np.ones((nt, 1)), :]
-        #    U = U[np.ones((nt, 1)), :]
-        # Let's try letting broadcasting take care of it.
-
     # gwch (astron arg)
     if ngflgs[3]:  # None (raw phase lags not Greenwich phase lags).
         freq = linearized_freqs(tref)
@@ -178,7 +173,9 @@ def FUV(t, tref, lind, lat, ngflgs):
         astro, ader = ut_astron(tt)
 
         V = np.dot(const.doodson, astro) + const.semi[:, None]
-        np.fmod(V, 1, out=V)
+        # V has nan values from both const.* arrays
+        with np.errstate(invalid="ignore"):
+            np.fmod(V, 1, out=V)
 
         for i0, nshal, k in zip(ishallow, nshallow, kshallow):
             ik = i0 + np.arange(nshal)


### PR DESCRIPTION
Closes #89.
Update test to python 3.9 and numpy 1.20; drop numpy 1.14.