### PR TITLE
Simplify ut_linci.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ doc/_build/
 .pydevproject
 .vscode/
 utide/_version.py
+
+# Mac
+.DS_Store

--- a/utide/confidence.py
+++ b/utide/confidence.py
@@ -423,19 +423,15 @@ def ut_linci(X, Y, sigX, sigY):
     # UTide v1p0 9/2011 d.codiga@gso.uri.edu
     # (adapted from errell.m of t_tide, Pawlowicz et al 2002)
 
-    X = np.array([X])
-    Y = np.array([Y])
-    sigX = np.array([sigX])
-    sigY = np.array([sigY])
-    Xu = np.real(X[:])
+    Xu = np.real(X)
     sigXu = np.real(sigX)
-    Yu = np.real(Y[:])
+    Yu = np.real(Y)
     sigYu = np.real(sigY)
 
-    Xv = np.imag(X[:])
-    sigXv = np.imag(sigX[:])
-    Yv = np.imag(Y[:])
-    sigYv = np.imag(sigY[:])
+    Xv = np.imag(X)
+    sigXv = np.imag(sigX)
+    Yv = np.imag(Y)
+    sigYv = np.imag(sigY)
 
     rp = 0.5 * np.sqrt((Xu + Yv) ** 2 + (Xv - Yu) ** 2)
     rm = 0.5 * np.sqrt((Xu - Yv) ** 2 + (Xv + Yu) ** 2)


### PR DESCRIPTION
This removes a numpy deprecation warning:
"DeprecationWarning: Conversion of an array with
ndim > 0 to a scalar is deprecated, and will error in future."